### PR TITLE
Skeleton parse functions

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -180,6 +180,11 @@ func parseExpAsInfix(buf TokenBuffer, exp ast.Expression, pre precedence) (ast.E
 	return nil, nil
 }
 
+// TODO: implement me w/ test cases :-)
+func parseInfixExpression(buf TokenBuffer, exp ast.Expression) (ast.Expression, []error) {
+	return nil, nil
+}
+
 func parseIdentifier(buf TokenBuffer) (ast.Expression, []error) {
 	errs := make([]error, 0)
 	token := buf.Peek(CURRENT)
@@ -203,5 +208,20 @@ func parseBooleanLiteral(buf TokenBuffer) (ast.Expression, []error) {
 
 // TODO: implement me w/ test cases :-)
 func parseStringLiteral(buf TokenBuffer) (ast.Expression, []error) {
+	return nil, nil
+}
+
+// TODO: implement me w/ test cases :-)
+func parseReturnStatement(buf TokenBuffer) (ast.Expression, []error) {
+	return nil, nil
+}
+
+// TODO: implement me w/ test cases :-)
+func parseAssignStatement(buf TokenBuffer) (*ast.AssignStatement, []error) {
+	return nil, nil
+}
+
+// TODO: implement me w/ test cases :-) (This used for calling built-in function)
+func parseCallExpression(buf TokenBuffer, fn ast.Expression) (ast.Expression, []error) {
 	return nil, nil
 }


### PR DESCRIPTION

Skeleton 
- `parseInfixExpression`
- `parseReturnStatement`
- `parseAssignStatement`
- `parseCallExpression`
