### PR TITLE
Implement assemble func prototype

### DIFF
--- a/opcode/constant.go
+++ b/opcode/constant.go
@@ -122,6 +122,15 @@ const (
 	//
 	Pop Type = 0x20
 
+	// Push the 32bits(uint32) item .
+	//
+	// Ex)
+	//           [a]
+	// [b]  ==>  [b]
+	// [x]       [x]
+	//
+	Push Type = 0x21
+
 	// Pop the first item in the stack.
 	// Load a value from memory and push it to the stack
 	//
@@ -130,7 +139,7 @@ const (
 	// [x]       ==>  [b]
 	// [y]            [x]
 	//
-	Mload Type = 0x21
+	Mload Type = 0x22
 
 	// Pop the first two items in the stack.
 	// Store the value with the first item(offset) as the offset of the memory.
@@ -141,5 +150,5 @@ const (
 	// [y]            [y]
 	//
 	// memory[offset:offset+32] = value
-	Mstore Type = 0x22
+	Mstore Type = 0x23
 )

--- a/vm/asm_internal_test.go
+++ b/vm/asm_internal_test.go
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package vm
+
+import (
+	"testing"
+
+	"bytes"
+
+	"github.com/DE-labtory/koa/opcode"
+)
+
+func TestAssemble(t *testing.T) {
+	rawByteCode := make([]byte, 0)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(1)...) // 1 byte allocation
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(300)...) // 2 byte allocation
+	rawByteCode = append(rawByteCode, uint8(opcode.Add))
+
+	testAsmExpected := asm{
+		code: []hexer{
+			push{}, Data{Body: uint32ToBytes(1)},
+			push{}, Data{Body: uint32ToBytes(300)},
+			add{},
+		},
+	}
+
+	asm, err := assemble(rawByteCode)
+	if err != nil {
+		t.Error(err)
+	}
+
+	//opCode is a byte
+	//Data is 4 bytes
+	for i, code := range asm.code {
+		switch code.(type) {
+		case opCode:
+			if !bytes.Equal(testAsmExpected.code[i].(opCode).hex(), code.(opCode).hex()) {
+				t.Fatal("There is an error in Opcode during analysis")
+			}
+		case Data:
+			if !bytes.Equal(testAsmExpected.code[i].(Data).hex(), code.(Data).hex()) {
+				t.Fatal("There is an error in Data during analysis")
+			}
+		}
+
+	}
+}
+
+func TestAssemble_invalid(t *testing.T) {
+	rawByteCode := make([]byte, 0)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(1)...)
+	rawByteCode = append(rawByteCode, uint8(255)) // invaild code
+	rawByteCode = append(rawByteCode, uint32ToBytes(300)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Add))
+
+	_, err := assemble(rawByteCode)
+	if err != ErrInvalidOpcode {
+		t.Error("The desired error was not found")
+	}
+}
+
+func TestNext(t *testing.T) {
+	rawByteCode := make([]byte, 0)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(1)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(2)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Add))
+
+	asm, err := assemble(rawByteCode)
+	if err != nil {
+		t.Error(err)
+	}
+
+	for asm.pc+1 < uint64(len(asm.code)) {
+		prevPc := asm.pc
+		code := asm.next()
+		if prevPc+1 != asm.pc {
+			t.Error("Error in moving pc")
+		}
+
+		_, ok := code.(hexer)
+		if !ok {
+			t.Errorf("Error at %d", asm.pc-1)
+		}
+	}
+
+	if asm.next() != nil {
+		t.Error("Error at last index")
+	}
+}
+
+func TestJump(t *testing.T) {
+	rawByteCode := make([]byte, 0)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(1)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(2)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Add))
+
+	asm, err := assemble(rawByteCode)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatal("Access to invalid program counter!")
+		}
+	}()
+	asm.jump(1)
+	if asm.pc != 1 {
+		t.Errorf("Invalid pc - expected=1, got=%d", asm.pc)
+	}
+
+	asm.jump(2)
+	if asm.pc != 2 {
+		t.Errorf("Invalid pc - expected=2, got=%d", asm.pc)
+	}
+
+	asm.jump(4)
+	if asm.pc != 4 {
+		t.Errorf("Invalid pc - expected=4, got=%d", asm.pc)
+	}
+}
+
+func TestJump_invalid(t *testing.T) {
+	rawByteCode := make([]byte, 0)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(1)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Push))
+	rawByteCode = append(rawByteCode, uint32ToBytes(2)...)
+	rawByteCode = append(rawByteCode, uint8(opcode.Add))
+
+	asm, err := assemble(rawByteCode)
+	if err != nil {
+		t.Error(err)
+	}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("The desired error was not found")
+		}
+	}()
+	asm.jump(15)
+	asm.jump(16)
+	asm.jump(17)
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -19,6 +19,8 @@ package vm
 import (
 	"errors"
 
+	"encoding/binary"
+
 	"github.com/DE-labtory/koa/opcode"
 )
 
@@ -57,11 +59,26 @@ type add struct{}
 
 // TODO: implement me w/ test cases :-)
 func (add) Do(stack *stack, _ asmReader) error {
-
 	return nil
 }
 
 // TODO: implement me w/ test cases :-)
 func (add) hex() []uint8 {
 	return []uint8{uint8(opcode.Add)}
+}
+
+type push struct{}
+
+func (push) Do(stack *stack, asm asmReader) error {
+	return nil
+}
+
+func (push) hex() []uint8 {
+	return []uint8{uint8(opcode.Push)}
+}
+
+func uint32ToBytes(uint32 uint32) []byte {
+	byteSlice := make([]byte, 4)
+	binary.BigEndian.PutUint32(byteSlice, uint32)
+	return byteSlice
 }


### PR DESCRIPTION
details:
We need to discuss about #60 
But when we implement opCodes( #61 ), it needs `asm.code` 
( it is analyzed `rawByteCode` but the analysis is focused on cost maybe. )

I think it is better to implement the analysis properly after it is fully discussed!! so i implement prototype of `analysis`...

- [x] Test case