### PR TITLE
Implement parseLiteral methods

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -115,9 +115,33 @@ type StringLiteral struct {
 
 func (sl *StringLiteral) produce() {}
 
-// TODO: implement me w/ test cases :-)
 func (sl *StringLiteral) String() string {
-	return ""
+	return sl.Value
+}
+
+// Represent integer literal
+type IntegerLiteral struct {
+	Value int64
+}
+
+func (il *IntegerLiteral) produce() {}
+
+func (il *IntegerLiteral) String() string {
+	return string(il.Value)
+}
+
+// Represent Boolean expression
+type BooleanLiteral struct {
+	Value bool
+}
+
+func (bl *BooleanLiteral) produce() {}
+
+func (bl *BooleanLiteral) String() string {
+	if bl.Value {
+		return "true"
+	}
+	return "false"
 }
 
 // Represent prefix expression

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -18,6 +18,7 @@ package parse
 
 import (
 	"errors"
+	"strconv"
 
 	"github.com/DE-labtory/koa/ast"
 )
@@ -191,17 +192,52 @@ func parseIdentifier(buf TokenBuffer) (ast.Expression, []error) {
 	return &ast.Identifier{Value: token.Val}, nil
 }
 
-// TODO: implement me w/ test cases :-)
 func parseIntegerLiteral(buf TokenBuffer) (ast.Expression, []error) {
-	return nil, nil
+	token := buf.Read()
+	errs := make([]error, 0)
+
+	if token.Type != Int {
+		errs = append(errs, errors.New("parseIntegerLiteral() error - "+token.Val+" is not integer"))
+		return nil, errs
+	}
+
+	value, err := strconv.ParseInt(token.Val, 0, 64)
+	if err != nil {
+		errs = append(errs, err)
+		return nil, errs
+	}
+
+	lit := &ast.IntegerLiteral{Value: value}
+	return lit, nil
 }
 
-// TODO: implement me w/ test cases :-)
 func parseBooleanLiteral(buf TokenBuffer) (ast.Expression, []error) {
-	return nil, nil
+	token := buf.Read()
+	errs := make([]error, 0)
+
+	if token.Type != Bool {
+		errs = append(errs, errors.New("parseBooleanLiteral() error - "+token.Val+" is not bool"))
+		return nil, errs
+	}
+
+	value, err := strconv.ParseBool(token.Val)
+	if err != nil {
+		errs = append(errs, err)
+		return nil, errs
+	}
+
+	lit := &ast.BooleanLiteral{Value: value}
+	return lit, nil
 }
 
-// TODO: implement me w/ test cases :-)
 func parseStringLiteral(buf TokenBuffer) (ast.Expression, []error) {
-	return nil, nil
+	token := buf.Read()
+	errs := make([]error, 0)
+
+	if token.Type != String {
+		errs = append(errs, errors.New("parseStringLiteral() error - "+token.Val+" is not string"))
+		return nil, errs
+	}
+
+	return &ast.StringLiteral{Value: token.Val}, nil
 }

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -331,3 +331,122 @@ func TestParseIdentifier(t *testing.T) {
 		}
 	}
 }
+
+func TestParseIntegerLiteral(t *testing.T) {
+	tokens := []Token{
+		{Type: Int, Val: "12"},
+		{Type: Int, Val: "55"},
+		{Type: Int, Val: "a"},
+		{Type: String, Val: "abcdefg"},
+		{Type: Int, Val: "-13"},
+	}
+	tokenBuf := mockTokenBuffer{tokens, 0}
+	tests := []struct {
+		expected    *ast.IntegerLiteral
+		expectedErr error
+	}{
+		{expected: &ast.IntegerLiteral{Value: 12}, expectedErr: nil},
+		{expected: &ast.IntegerLiteral{Value: 55}, expectedErr: nil},
+		{expected: nil, expectedErr: errors.New("strconv.ParseInt: parsing \"a\": invalid syntax")},
+		{expected: nil, expectedErr: errors.New("parseIntegerLiteral() error - abcdefg is not integer")},
+		{expected: &ast.IntegerLiteral{Value: -13}, expectedErr: nil},
+	}
+
+	for i, test := range tests {
+		exp, err := parseIntegerLiteral(&tokenBuf)
+
+		switch err != nil {
+		case true:
+			if err[0].Error() != test.expectedErr.Error() {
+				t.Fatalf("test[%d] - TestParseIntegerLiteral() wrong error. expected=%s, got=%s",
+					i, test.expectedErr, err[0].Error())
+			}
+		}
+
+		switch exp != nil {
+		case true:
+			if exp.String() != test.expected.String() {
+				t.Fatalf("test[%d] - TestParseIntegerLiteral() wrong error. expected=%s, got=%s",
+					i, test.expectedErr, err[0].Error())
+			}
+		}
+	}
+}
+
+func TestParseBooleanLiteral(t *testing.T) {
+	tokens := []Token{
+		{Type: Bool, Val: "true"},
+		{Type: Bool, Val: "false"},
+		{Type: Bool, Val: "azzx"},
+		{Type: String, Val: "abcdefg"},
+	}
+	tokenBuf := mockTokenBuffer{tokens, 0}
+	tests := []struct {
+		expected    *ast.BooleanLiteral
+		expectedErr error
+	}{
+		{expected: &ast.BooleanLiteral{Value: true}, expectedErr: nil},
+		{expected: &ast.BooleanLiteral{Value: false}, expectedErr: nil},
+		{expected: nil, expectedErr: errors.New("strconv.ParseBool: parsing \"azzx\": invalid syntax")},
+		{expected: nil, expectedErr: errors.New("parseBooleanLiteral() error - abcdefg is not bool")},
+	}
+
+	for i, test := range tests {
+		exp, err := parseBooleanLiteral(&tokenBuf)
+
+		switch err != nil {
+		case true:
+			if err[0].Error() != test.expectedErr.Error() {
+				t.Fatalf("test[%d] - TestParseBooleanLiteral() wrong error. expected=%s, got=%s",
+					i, test.expectedErr, err[0].Error())
+			}
+		}
+
+		switch exp != nil {
+		case true:
+			if exp.String() != test.expected.String() {
+				t.Fatalf("test[%d] - TestParseBooleanLiteral() wrong result. expected=%s, got=%s",
+					i, test.expected, exp.String())
+			}
+		}
+	}
+}
+
+func TestParseStringLiteral(t *testing.T) {
+	tokens := []Token{
+		{Type: String, Val: "hello"},
+		{Type: String, Val: "hihi"},
+		{Type: Int, Val: "3"},
+		{Type: String, Val: "koa zzang"},
+	}
+	tokenBuf := mockTokenBuffer{tokens, 0}
+	tests := []struct {
+		expected    *ast.StringLiteral
+		expectedErr error
+	}{
+		{expected: &ast.StringLiteral{Value: "hello"}, expectedErr: nil},
+		{expected: &ast.StringLiteral{Value: "hihi"}, expectedErr: nil},
+		{expected: nil, expectedErr: errors.New("parseStringLiteral() error - 3 is not string")},
+		{expected: &ast.StringLiteral{Value: "koa zzang"}, expectedErr: nil},
+	}
+
+	for i, test := range tests {
+		exp, err := parseStringLiteral(&tokenBuf)
+
+		switch err != nil {
+		case true:
+			if err[0].Error() != test.expectedErr.Error() {
+				t.Fatalf("test[%d] - TestParseStringLiteral() wrong error. expected=%s, got=%s",
+					i, test.expectedErr, err[0].Error())
+			}
+		}
+
+		switch exp != nil {
+		case true:
+			if exp.String() != test.expected.String() {
+				t.Fatalf("test[%d] - TestParseStringLiteral() wrong result. expected=%s, got=%s",
+					i, test.expected, exp.String())
+			}
+		}
+	}
+}


### PR DESCRIPTION
resolved: #46, #47, #48, #49

1. Implement StringLiteral, IntegerLiteral, BooleanLiteral struct
2. Implement parseStringLiteral, IntegerLiteral, BooleanLiteral and test cases

- [x] Test case