### PR TITLE
Implement makePrefixExpression w/ test case

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -172,11 +172,15 @@ func parseExpression(buf TokenBuffer, pre precedence) (ast.Expression, []error) 
 }
 
 // TODO: implement me w/ test cases :-)
+// ParseExpAsPrefix retrieves prefix parse function from
+// map, then parse expression with that function if exist.
 func parseExpAsPrefix(buf TokenBuffer) (ast.Expression, []error) {
 	return nil, nil
 }
 
 // TODO: implement me w/ test cases :-)
+// ParseExpAsInfix retrieves infix parse function from map
+// then parse expression with that function if exist.
 func parseExpAsInfix(buf TokenBuffer, exp ast.Expression, pre precedence) (ast.Expression, []error) {
 	return nil, nil
 }
@@ -261,3 +265,4 @@ func parseAssignStatement(buf TokenBuffer) (*ast.AssignStatement, []error) {
 func parseCallExpression(buf TokenBuffer, fn ast.Expression) (ast.Expression, []error) {
 	return nil, nil
 }
+


### PR DESCRIPTION
resolved: #64 

details:

Implement `makePrefixExpression`, we are now not implemented all the parsing function so wrote test cases not for real situation but for this function work correctly for given input and results are what we expected

- [x] Test case