### PR TITLE
VM opcode skeleton

### DIFF
--- a/vm/asm.go
+++ b/vm/asm.go
@@ -22,6 +22,10 @@ import (
 
 var opCodes = map[opcode.Type]opCode{
 	opcode.Add:  add{},
+	opcode.Mul:  mul{},
+	opcode.Sub:  sub{},
+	opcode.Div:  div{},
+	opcode.Mod:  mod{},
 	opcode.Push: push{},
 }
 

--- a/vm/asm.go
+++ b/vm/asm.go
@@ -26,7 +26,7 @@ var opCodes = map[opcode.Type]opCode{
 }
 
 // Converts rawByteCode to assembly code.
-func assemble(rawByteCode []byte) (*asm, error) {
+func disassemble(rawByteCode []byte) (*asm, error) {
 	asm := newAsm()
 
 	for i := 0; i < len(rawByteCode); i++ {

--- a/vm/asm_internal_test.go
+++ b/vm/asm_internal_test.go
@@ -38,7 +38,7 @@ func TestAssemble(t *testing.T) {
 		},
 	}
 
-	asm, err := assemble(testByteCode)
+	asm, err := disassemble(testByteCode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -67,7 +67,7 @@ func TestAssemble_invalid(t *testing.T) {
 		uint8(opcode.Add),
 	)
 
-	_, err := assemble(testByteCode)
+	_, err := disassemble(testByteCode)
 	if err != ErrInvalidOpcode {
 		t.Error("The desired error was not found")
 	}
@@ -80,7 +80,7 @@ func TestNext(t *testing.T) {
 		uint8(opcode.Add),
 	)
 
-	asm, err := assemble(testByteCode)
+	asm, err := disassemble(testByteCode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -110,7 +110,7 @@ func TestJump(t *testing.T) {
 		uint8(opcode.Add),
 	)
 
-	asm, err := assemble(testByteCode)
+	asm, err := disassemble(testByteCode)
 	if err != nil {
 		t.Error(err)
 	}
@@ -142,7 +142,7 @@ func TestJump_invalid(t *testing.T) {
 		uint8(opcode.Add),
 	)
 
-	asm, err := assemble(testByteCode)
+	asm, err := disassemble(testByteCode)
 	if err != nil {
 		t.Error(err)
 	}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -73,11 +73,15 @@ type mload struct{}
 type mstore struct{}
 
 func (add) Do(stack *stack, _ asmReader) error {
-	rightValue := stack.pop()
-	leftValue := stack.pop()
-	result := rightValue + leftValue
+	y := stack.pop()
+	x := stack.pop()
 
-	stack.push(result)
+	X := int(x)
+	Y := int(y)
+
+	item := item(X + Y)
+
+	stack.push(item)
 
 	return nil
 }
@@ -86,8 +90,17 @@ func (add) hex() []uint8 {
 	return []uint8{uint8(opcode.Add)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (mul) Do(stack *stack, _ asmReader) error {
+	y := stack.pop()
+	x := stack.pop()
+
+	X := int(x)
+	Y := int(y)
+
+	item := item(X * Y)
+
+	stack.push(item)
+
 	return nil
 }
 
@@ -95,8 +108,17 @@ func (mul) hex() []uint8 {
 	return []uint8{uint8(opcode.Mul)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (sub) Do(stack *stack, _ asmReader) error {
+	y := stack.pop()
+	x := stack.pop()
+
+	X := int(x)
+	Y := int(y)
+
+	item := item(X - Y)
+
+	stack.push(item)
+
 	return nil
 }
 
@@ -104,8 +126,15 @@ func (sub) hex() []uint8 {
 	return []uint8{uint8(opcode.Sub)}
 }
 
-// TODO: implement me w/ test cases :-)
+// Be careful! int.Div and int.Quo is different
 func (div) Do(stack *stack, _ asmReader) error {
+	y := stack.pop()
+	x := stack.pop()
+
+	item, _ := euclidean_div(x, y)
+
+	stack.push(item)
+
 	return nil
 }
 
@@ -113,8 +142,14 @@ func (div) hex() []uint8 {
 	return []uint8{uint8(opcode.Div)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (mod) Do(stack *stack, _ asmReader) error {
+	y := stack.pop()
+	x := stack.pop()
+
+	_, item := euclidean_div(x, y)
+
+	stack.push(item)
+
 	return nil
 }
 
@@ -210,4 +245,27 @@ func uint32ToBytes(uint32 uint32) []byte {
 func bytesToUint32(bytes []byte) uint32 {
 	uint32 := binary.BigEndian.Uint32(bytes)
 	return uint32
+}
+
+func euclidean_div(a item, b item) (item, item) {
+	var q int32
+	var r int32
+	A := int32(a)
+	B := int32(b)
+
+	if A < 0 && B > 0 {
+		q = int32(A/B) - 1
+		r = A - (B * q)
+	} else if A > 0 && B < 0 {
+		q = int32(A / B)
+		r = A - (B * q)
+	} else if A > 0 && B > 0 {
+		q = int32(A / B)
+		r = A - (B * q)
+	} else if A < 0 && B < 0 {
+		q = int32((A + B) / B)
+		r = A - (B * q)
+	}
+
+	return item(q), item(r)
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -32,7 +32,7 @@ var ErrInvalidOpcode = errors.New("invalid opcode")
 func Execute(rawByteCode []byte) (*stack, error) {
 
 	s := newStack()
-	asm, err := assemble(rawByteCode)
+	asm, err := disassemble(rawByteCode)
 	if err != nil {
 		return &stack{}, err
 	}
@@ -57,10 +57,21 @@ type opCode interface {
 	hexer
 }
 
-// Perform add opcode logic.
+// Perform opcodes logic.
 type add struct{}
+type mul struct{}
+type sub struct{}
+type div struct{}
+type mod struct{}
+type lt struct{}
+type gt struct{}
+type eq struct{}
+type not struct{}
+type pop struct{}
+type push struct{}
+type mload struct{}
+type mstore struct{}
 
-// TODO: implement me w/ test cases :-)
 func (add) Do(stack *stack, _ asmReader) error {
 	rightValue := stack.pop()
 	leftValue := stack.pop()
@@ -71,12 +82,90 @@ func (add) Do(stack *stack, _ asmReader) error {
 	return nil
 }
 
-// TODO: implement me w/ test cases :-)
 func (add) hex() []uint8 {
 	return []uint8{uint8(opcode.Add)}
 }
 
-type push struct{}
+// TODO: implement me w/ test cases :-)
+func (mul) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (mul) hex() []uint8 {
+	return []uint8{uint8(opcode.Mul)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (sub) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (sub) hex() []uint8 {
+	return []uint8{uint8(opcode.Sub)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (div) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (div) hex() []uint8 {
+	return []uint8{uint8(opcode.Div)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (mod) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (mod) hex() []uint8 {
+	return []uint8{uint8(opcode.Mod)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (lt) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (lt) hex() []uint8 {
+	return []uint8{uint8(opcode.LT)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (gt) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (gt) hex() []uint8 {
+	return []uint8{uint8(opcode.GT)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (eq) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (eq) hex() []uint8 {
+	return []uint8{uint8(opcode.EQ)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (not) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (not) hex() []uint8 {
+	return []uint8{uint8(opcode.NOT)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (pop) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (pop) hex() []uint8 {
+	return []uint8{uint8(opcode.Pop)}
+}
 
 func (push) Do(stack *stack, asm asmReader) error {
 	code := asm.next()
@@ -92,6 +181,24 @@ func (push) Do(stack *stack, asm asmReader) error {
 
 func (push) hex() []uint8 {
 	return []uint8{uint8(opcode.Push)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (mload) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (mload) hex() []uint8 {
+	return []uint8{uint8(opcode.Mload)}
+}
+
+// TODO: implement me w/ test cases :-)
+func (mstore) Do(stack *stack, _ asmReader) error {
+	return nil
+}
+
+func (mstore) hex() []uint8 {
+	return []uint8{uint8(opcode.Mstore)}
 }
 
 func uint32ToBytes(uint32 uint32) []byte {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -41,6 +41,70 @@ func makeTestByteCode(slice ...interface{}) []byte {
 	return testByteCode
 }
 
+func TestAdd(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(1),
+		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Add),
+	)
+	testExpected := item(3)
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
+// TODO: implement test cases :-)
+func TestMul(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestSub(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestDiv(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestMod(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestLT(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestGT(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestEQ(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestNOT(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestPop(t *testing.T) {
+
+}
+
 func TestPush(t *testing.T) {
 	testByteCode := makeTestByteCode(
 		uint8(opcode.Push), uint32ToBytes(1),
@@ -76,21 +140,12 @@ func TestPush_invalid(t *testing.T) {
 	}
 }
 
-func TestAdd(t *testing.T) {
-	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
-		uint8(opcode.Add),
-	)
-	testExpected := item(3)
+// TODO: implement test cases :-)
+func TestMload(t *testing.T) {
 
-	stack, err := Execute(testByteCode)
+}
 
-	if err != nil {
-		t.Error(err)
-	}
-	result := stack.pop()
-	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
-	}
+// TODO: implement test cases :-)
+func TestMstore(t *testing.T) {
+
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -60,24 +60,176 @@ func TestAdd(t *testing.T) {
 	}
 }
 
-// TODO: implement test cases :-)
+func TestAdd_negative(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
+		uint8(opcode.Push), uint32ToBytes(30),
+		uint8(opcode.Add),
+	)
+	testExpected := item(10)
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
 func TestMul(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(3),
+		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Mul),
+	)
+	testExpected := item(15)
 
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
 }
 
-// TODO: implement test cases :-)
+func TestMul_negative(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(0XFFFFFFFD), // FFFFFFFD : -3
+		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Mul),
+	)
+	testExpected := item(0xFFFFFFF1) // FFFFFFF1 : -15
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
 func TestSub(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(50),
+		uint8(opcode.Push), uint32ToBytes(20),
+		uint8(opcode.Sub),
+	)
+	testExpected := item(30)
 
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
 }
 
-// TODO: implement test cases :-)
+func TestSub_negative(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
+		uint8(opcode.Push), uint32ToBytes(50),
+		uint8(opcode.Sub),
+	)
+	testExpected := item(0xFFFFFFBA) // 0xFFFFFFBA : -70
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
 func TestDiv(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(14),
+		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Div),
+	)
+	testExpected := item(2)
 
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
 }
 
-// TODO: implement test cases :-)
-func TestMod(t *testing.T) {
+// Be careful! int.Div and int.Quo is different
+func TestDiv_negative(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
+		uint8(opcode.Push), uint32ToBytes(6),
+		uint8(opcode.Div),
+	)
+	testExpected := item(0xFFFFFFFC) // 0xFFFFFFFC : -4
 
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
+func TestMod(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(14),
+		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Mod),
+	)
+	testExpected := item(4)
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
+}
+
+func TestMod_negative(t *testing.T) {
+	testByteCode := makeTestByteCode(
+		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
+		uint8(opcode.Push), uint32ToBytes(6),
+		uint8(opcode.Mod),
+	)
+	testExpected := item(4)
+
+	stack, err := Execute(testByteCode)
+
+	if err != nil {
+		t.Error(err)
+	}
+	result := stack.pop()
+	if testExpected != result {
+		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+	}
 }
 
 // TODO: implement test cases :-)


### PR DESCRIPTION
details:

1. Renamed `assemble` -> `disassemble`
2. Defined opcodes skeleton
3. Implement negative numbers operate

ᅟI have a issue here.
Ethereum use `big.int` and use the operation method in `big.int` like a `big.Add`, `big.Sub`, `big.Mul`, `big.Div`, `big.Mod`. but `big.Div` and `big.Mod` use Euclidean division (unlike Go!!)

For example,  
int a = -20
int b = 30
result of a/b is -1 and a%b is 10. not a 0 and 10.

plz review...! :)