### PR TITLE
Modify identifierStateFn and add keyword Map

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -279,7 +279,6 @@ func numberStateFn(s *state, e emitter) stateFn {
 	return defaultStateFn
 }
 
-// TODO: Need to check Keyword
 // IdentifierStateFn scans an identifiers. ex) a, b, add
 // After reading a identifier, it returns DefaultStateFn.
 //
@@ -299,7 +298,9 @@ func identifierStateFn(s *state, e emitter) stateFn {
 		s.next()
 	}
 
-	e.emit(s.cut(Ident))
+	//lookup keywords map and return tokenType
+	tok := LookupIdent(s.input[s.start:s.end])
+	e.emit(s.cut(tok))
 	return defaultStateFn
 }
 

--- a/parse/lex_internal_test.go
+++ b/parse/lex_internal_test.go
@@ -351,13 +351,23 @@ func TestIdentifierStateFn(t *testing.T) {
 		{"a1123", Ident, "a1123"},
 		{"_var123", Ident, "_var123"},
 		{"_var_123", Ident, "_var_123"},
+		{"thisIsIdent", Ident, "thisIsIdent"},
+		{"function", Ident, "function"},
+		{"func", Function, "func"},
+		{"if", If, "if"},
+		{"else", Else, "else"},
+		{"int", IntType, "int"},
+		{"string", StringType, "string"},
+		{"return", Return, "return"},
+		{"true", True, "true"},
+		{"false", False, "false"},
 	}
 
 	for i, test := range tests {
 		s := &state{input: test.input}
 		e := MockEmitter{}
 		e.emitFunc = func(tok Token) {
-			if tok.Type != Ident {
+			if tok.Type != test.expectedType {
 				t.Errorf("tests[%d] - Wrong token type", i)
 			}
 			if tok.Val != test.expectedVal {

--- a/parse/token.go
+++ b/parse/token.go
@@ -33,10 +33,11 @@ const (
 	Illegal TokenType = iota
 
 	// Identifiers + literals
-	Ident  // add, foobar, x, y, ...
-	Int    // 1343456
-	String // "hello world"
-	Bool   // true, false
+	Ident    // add, foobar, x, y, ...
+	Int      // 1343456
+	String   // "hello world"
+	Bool     // true, false
+	Function // func
 
 	IntType
 	StringType
@@ -113,4 +114,22 @@ var TokenTypeMap = map[TokenType]string{
 	If:     "IF",
 	Else:   "ELSE",
 	Return: "RETURN",
+}
+
+var keywords = map[string]TokenType{
+	"func":   Function,
+	"if":     If,
+	"else":   Else,
+	"int":    IntType,
+	"string": StringType,
+	"return": Return,
+	"true":   True,
+	"false":  False,
+}
+
+func LookupIdent(ident string) TokenType {
+	if tok, ok := keywords[ident]; ok {
+		return tok
+	}
+	return Ident
 }

--- a/parse/token_test.go
+++ b/parse/token_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parse
+
+import "testing"
+
+func TestLookupIdent(t *testing.T) {
+	tests := []struct {
+		inputString       string
+		expectedTokenType TokenType
+	}{
+		{"thisIsIdent", Ident},
+		{"function", Ident},
+		{"func", Function},
+		{"if", If},
+		{"else", Else},
+		{"int", IntType},
+		{"string", StringType},
+		{"return", Return},
+		{"true", True},
+		{"false", False},
+	}
+
+	for i, test := range tests {
+		input := test.inputString
+		tokType := LookupIdent(input)
+
+		if tokType != test.expectedTokenType {
+			t.Fatalf("tests[%d] - wrong token Type. expected=%q, got=%q",
+				i, test.expectedTokenType, input)
+		}
+	}
+
+}


### PR DESCRIPTION
resolved: #92 

details:
1. Modify identifierStateFn - now it checks keyword map and return proper tokenType
2. Add LookupIdent Function  & keywords map in token.go

- [x] Test case