### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ It is expressed in `if(){}` or `if(){}else{}`.
 - Assign : It is expressed in `=`.
 
 #### Example Code
- ```
+ ```go
  func Sig(sig string){
    string pubkey = "fvfidBGruUYC+mTw7CusaCOQbBuZBiYduFgH8hRW97KLmHn0xzB1FV++KI7syo8qXGo8Un24WP40IT78XjKO"
  


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.
