### PR TITLE
Implement opcode NOT/EQ/GT/LT w/ testcase

### DIFF
--- a/opcode/constant.go
+++ b/opcode/constant.go
@@ -107,7 +107,7 @@ const (
 	// Reverse the sign and push it to the stack.
 	//
 	// Ex)
-	// [a]       [-a]
+	// [a]       [~a]
 	// [b]  ==>  [b]
 	// [x]       [x]
 	//

--- a/vm/asm.go
+++ b/vm/asm.go
@@ -27,6 +27,10 @@ var opCodes = map[opcode.Type]opCode{
 	opcode.Div:  div{},
 	opcode.Mod:  mod{},
 	opcode.Push: push{},
+	opcode.LT:   lt{},
+	opcode.GT:   gt{},
+	opcode.EQ:   eq{},
+	opcode.NOT:  not{},
 }
 
 // Converts rawByteCode to assembly code.

--- a/vm/asm_internal_test.go
+++ b/vm/asm_internal_test.go
@@ -26,14 +26,14 @@ import (
 
 func TestAssemble(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1), // 1 byte allocation
-		uint8(opcode.Push), uint32ToBytes(300), // 2 byte allocation
+		uint8(opcode.Push), int32ToBytes(1), // 1 byte allocation
+		uint8(opcode.Push), int32ToBytes(300), // 2 byte allocation
 		uint8(opcode.Add),
 	)
 	testAsmExpected := asm{
 		code: []hexer{
-			push{}, Data{Body: uint32ToBytes(1)},
-			push{}, Data{Body: uint32ToBytes(300)},
+			push{}, Data{Body: int32ToBytes(1)},
+			push{}, Data{Body: int32ToBytes(300)},
 			add{},
 		},
 	}
@@ -62,8 +62,8 @@ func TestAssemble(t *testing.T) {
 
 func TestAssemble_invalid(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(255), uint32ToBytes(300),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(255), int32ToBytes(300),
 		uint8(opcode.Add),
 	)
 
@@ -75,8 +75,8 @@ func TestAssemble_invalid(t *testing.T) {
 
 func TestNext(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(opcode.Push), int32ToBytes(2),
 		uint8(opcode.Add),
 	)
 
@@ -105,8 +105,8 @@ func TestNext(t *testing.T) {
 
 func TestJump(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(opcode.Push), int32ToBytes(2),
 		uint8(opcode.Add),
 	)
 
@@ -137,8 +137,8 @@ func TestJump(t *testing.T) {
 
 func TestJump_invalid(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(opcode.Push), int32ToBytes(2),
 		uint8(opcode.Add),
 	)
 

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -22,7 +22,7 @@ const (
 	stackMaxSize = 1024
 )
 
-type item uint32
+type item int32
 
 // Stack is an object for basic stack operations. Items popped to the stack are
 // expected not to be changed and modified.

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -17,9 +17,8 @@
 package vm
 
 import (
-	"errors"
-
 	"encoding/binary"
+	"errors"
 
 	"github.com/DE-labtory/koa/opcode"
 )
@@ -76,12 +75,7 @@ func (add) Do(stack *stack, _ asmReader) error {
 	y := stack.pop()
 	x := stack.pop()
 
-	X := int(x)
-	Y := int(y)
-
-	item := item(X + Y)
-
-	stack.push(item)
+	stack.push(x + y)
 
 	return nil
 }
@@ -94,12 +88,7 @@ func (mul) Do(stack *stack, _ asmReader) error {
 	y := stack.pop()
 	x := stack.pop()
 
-	X := int(x)
-	Y := int(y)
-
-	item := item(X * Y)
-
-	stack.push(item)
+	stack.push(x * y)
 
 	return nil
 }
@@ -112,12 +101,7 @@ func (sub) Do(stack *stack, _ asmReader) error {
 	y := stack.pop()
 	x := stack.pop()
 
-	X := int(x)
-	Y := int(y)
-
-	item := item(X - Y)
-
-	stack.push(item)
+	stack.push(x - y)
 
 	return nil
 }
@@ -157,8 +141,15 @@ func (mod) hex() []uint8 {
 	return []uint8{uint8(opcode.Mod)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (lt) Do(stack *stack, _ asmReader) error {
+	y, x := stack.pop(), stack.pop()
+
+	if x < y { // x < y
+		stack.push(item(1))
+	} else {
+		stack.push(item(0))
+	}
+
 	return nil
 }
 
@@ -166,8 +157,15 @@ func (lt) hex() []uint8 {
 	return []uint8{uint8(opcode.LT)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (gt) Do(stack *stack, _ asmReader) error {
+	y, x := stack.pop(), stack.pop()
+
+	if x > y { // x > y
+		stack.push(item(1))
+	} else {
+		stack.push(item(0))
+	}
+
 	return nil
 }
 
@@ -175,8 +173,15 @@ func (gt) hex() []uint8 {
 	return []uint8{uint8(opcode.GT)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (eq) Do(stack *stack, _ asmReader) error {
+	y, x := stack.pop(), stack.pop()
+
+	if x == y { // x == y
+		stack.push(item(1))
+	} else {
+		stack.push(item(0))
+	}
+
 	return nil
 }
 
@@ -184,8 +189,10 @@ func (eq) hex() []uint8 {
 	return []uint8{uint8(opcode.EQ)}
 }
 
-// TODO: implement me w/ test cases :-)
 func (not) Do(stack *stack, _ asmReader) error {
+	x := stack.pop()
+
+	stack.push(^x)
 	return nil
 }
 
@@ -208,7 +215,7 @@ func (push) Do(stack *stack, asm asmReader) error {
 	if !ok {
 		return ErrInvalidData
 	}
-	item := item(bytesToUint32(data.hex()))
+	item := item(bytesToInt32(data.hex()))
 	stack.push(item)
 
 	return nil
@@ -236,15 +243,15 @@ func (mstore) hex() []uint8 {
 	return []uint8{uint8(opcode.Mstore)}
 }
 
-func uint32ToBytes(uint32 uint32) []byte {
+func int32ToBytes(int32 int32) []byte {
 	byteSlice := make([]byte, 4)
-	binary.BigEndian.PutUint32(byteSlice, uint32)
+	binary.BigEndian.PutUint32(byteSlice, uint32(int32))
 	return byteSlice
 }
 
-func bytesToUint32(bytes []byte) uint32 {
-	uint32 := binary.BigEndian.Uint32(bytes)
-	return uint32
+func bytesToInt32(bytes []byte) int32 {
+	int32 := int32(binary.BigEndian.Uint32(bytes))
+	return int32
 }
 
 func euclidean_div(a item, b item) (item, item) {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -43,8 +43,8 @@ func makeTestByteCode(slice ...interface{}) []byte {
 
 func TestAdd(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(opcode.Push), int32ToBytes(2),
 		uint8(opcode.Add),
 	)
 	testExpected := item(3)
@@ -62,8 +62,8 @@ func TestAdd(t *testing.T) {
 
 func TestAdd_negative(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
-		uint8(opcode.Push), uint32ToBytes(30),
+		uint8(opcode.Push), int32ToBytes(-20),
+		uint8(opcode.Push), int32ToBytes(30),
 		uint8(opcode.Add),
 	)
 	testExpected := item(10)
@@ -81,8 +81,8 @@ func TestAdd_negative(t *testing.T) {
 
 func TestMul(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(3),
-		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Push), int32ToBytes(3),
+		uint8(opcode.Push), int32ToBytes(5),
 		uint8(opcode.Mul),
 	)
 	testExpected := item(15)
@@ -100,11 +100,11 @@ func TestMul(t *testing.T) {
 
 func TestMul_negative(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(0XFFFFFFFD), // FFFFFFFD : -3
-		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Push), int32ToBytes(-3),
+		uint8(opcode.Push), int32ToBytes(5),
 		uint8(opcode.Mul),
 	)
-	testExpected := item(0xFFFFFFF1) // FFFFFFF1 : -15
+	testExpected := item(-15)
 
 	stack, err := Execute(testByteCode)
 
@@ -119,8 +119,8 @@ func TestMul_negative(t *testing.T) {
 
 func TestSub(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(50),
-		uint8(opcode.Push), uint32ToBytes(20),
+		uint8(opcode.Push), int32ToBytes(50),
+		uint8(opcode.Push), int32ToBytes(20),
 		uint8(opcode.Sub),
 	)
 	testExpected := item(30)
@@ -138,11 +138,11 @@ func TestSub(t *testing.T) {
 
 func TestSub_negative(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
-		uint8(opcode.Push), uint32ToBytes(50),
+		uint8(opcode.Push), int32ToBytes(-20),
+		uint8(opcode.Push), int32ToBytes(50),
 		uint8(opcode.Sub),
 	)
-	testExpected := item(0xFFFFFFBA) // 0xFFFFFFBA : -70
+	testExpected := item(-70)
 
 	stack, err := Execute(testByteCode)
 
@@ -157,8 +157,8 @@ func TestSub_negative(t *testing.T) {
 
 func TestDiv(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(14),
-		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Push), int32ToBytes(14),
+		uint8(opcode.Push), int32ToBytes(5),
 		uint8(opcode.Div),
 	)
 	testExpected := item(2)
@@ -177,11 +177,11 @@ func TestDiv(t *testing.T) {
 // Be careful! int.Div and int.Quo is different
 func TestDiv_negative(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
-		uint8(opcode.Push), uint32ToBytes(6),
+		uint8(opcode.Push), int32ToBytes(-20),
+		uint8(opcode.Push), int32ToBytes(6),
 		uint8(opcode.Div),
 	)
-	testExpected := item(0xFFFFFFFC) // 0xFFFFFFFC : -4
+	testExpected := item(-4)
 
 	stack, err := Execute(testByteCode)
 
@@ -196,8 +196,8 @@ func TestDiv_negative(t *testing.T) {
 
 func TestMod(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(14),
-		uint8(opcode.Push), uint32ToBytes(5),
+		uint8(opcode.Push), int32ToBytes(14),
+		uint8(opcode.Push), int32ToBytes(5),
 		uint8(opcode.Mod),
 	)
 	testExpected := item(4)
@@ -215,8 +215,8 @@ func TestMod(t *testing.T) {
 
 func TestMod_negative(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(0xFFFFFFEC), // 0xFFFFFFEC : -20
-		uint8(opcode.Push), uint32ToBytes(6),
+		uint8(opcode.Push), int32ToBytes(-20),
+		uint8(opcode.Push), int32ToBytes(6),
 		uint8(opcode.Mod),
 	)
 	testExpected := item(4)
@@ -232,24 +232,124 @@ func TestMod_negative(t *testing.T) {
 	}
 }
 
-// TODO: implement test cases :-)
 func TestLT(t *testing.T) {
+	tests := []struct {
+		x      int32
+		y      int32
+		answer int
+	}{
+		{1, 2, 1}, // true = 1 , false = 0
+		{2, 1, 0},
+		{-20, -21, 0},
+		{-21, -20, 1},
+	}
 
+	for i, test := range tests {
+		testByteCode := makeTestByteCode(
+			uint8(opcode.Push), int32ToBytes(test.x),
+			uint8(opcode.Push), int32ToBytes(test.y),
+			uint8(opcode.LT),
+		)
+		testExpected := item(test.answer)
+
+		stack, err := Execute(testByteCode)
+		if err != nil {
+			t.Error(err)
+		}
+		result := stack.pop()
+		if testExpected != result {
+			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+		}
+	}
 }
 
-// TODO: implement test cases :-)
 func TestGT(t *testing.T) {
+	tests := []struct {
+		x      int32
+		y      int32
+		answer int
+	}{
+		{1, 2, 0}, // true = 1 , false = 0
+		{2, 1, 1},
+		{-20, -21, 1},
+		{-21, 20, 0},
+	}
 
+	for i, test := range tests {
+		testByteCode := makeTestByteCode(
+			uint8(opcode.Push), int32ToBytes(test.x),
+			uint8(opcode.Push), int32ToBytes(test.y),
+			uint8(opcode.GT),
+		)
+		testExpected := item(test.answer)
+
+		stack, err := Execute(testByteCode)
+		if err != nil {
+			t.Error(err)
+		}
+		result := stack.pop()
+		if testExpected != result {
+			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+		}
+	}
 }
 
-// TODO: implement test cases :-)
 func TestEQ(t *testing.T) {
+	tests := []struct {
+		x      int32
+		y      int32
+		answer int
+	}{
+		{1, 1, 1}, // true = 1 , false = 0
+		{2, 1, 0},
+		{-20, -20, 1},
+		{-20, -21, 0},
+	}
 
+	for i, test := range tests {
+		testByteCode := makeTestByteCode(
+			uint8(opcode.Push), int32ToBytes(test.x),
+			uint8(opcode.Push), int32ToBytes(test.y),
+			uint8(opcode.EQ),
+		)
+		testExpected := item(test.answer)
+
+		stack, err := Execute(testByteCode)
+		if err != nil {
+			t.Error(err)
+		}
+		result := stack.pop()
+		if testExpected != result {
+			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+		}
+	}
 }
 
-// TODO: implement test cases :-)
 func TestNOT(t *testing.T) {
+	tests := []struct {
+		x      int32
+		answer int32
+	}{
+		{0, -1}, // ^x = -x-1  0x00000000 -> 0xFFFFFFFF
+		{3, -4},
+	}
 
+	for i, test := range tests {
+		testByteCode := makeTestByteCode(
+			uint8(opcode.Push), int32ToBytes(test.x),
+			uint8(opcode.NOT),
+		)
+		testExpected := item(test.answer)
+
+		stack, err := Execute(testByteCode)
+		if err != nil {
+			t.Error(err)
+		}
+		result := stack.pop()
+		if testExpected != result {
+			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+		}
+	}
 }
 
 // TODO: implement test cases :-)
@@ -259,8 +359,8 @@ func TestPop(t *testing.T) {
 
 func TestPush(t *testing.T) {
 	testByteCode := makeTestByteCode(
-		uint8(opcode.Push), uint32ToBytes(1),
-		uint8(opcode.Push), uint32ToBytes(2),
+		uint8(opcode.Push), int32ToBytes(1),
+		uint8(opcode.Push), int32ToBytes(2),
 	)
 
 	testExpected := []item{1, 2}
@@ -282,7 +382,7 @@ func TestPush(t *testing.T) {
 func TestPush_invalid(t *testing.T) {
 	testByteCode := makeTestByteCode(
 		uint8(opcode.Push), uint8(opcode.Push),
-		uint8(opcode.Push), uint32ToBytes(3),
+		uint8(opcode.Push), int32ToBytes(3),
 	)
 
 	_, err := Execute(testByteCode)


### PR DESCRIPTION
resolved: #100 #101 #102 #103 

details:
Implement opcode NOT/EQ/GT/LT w/ testcase

+ change item type. uint32 to int32
+ comment: in case of OpDiv and OpMod, we use euclidian div instead standard div
ex) -15 / 6 = -3 ( not -2)
- [ ] Test case