### PR TITLE
Fix condition of parseBooleanLiteral & Remove stretchr test module

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -319,7 +319,7 @@ func parseIntegerLiteral(buf TokenBuffer) (ast.Expression, error) {
 func parseBooleanLiteral(buf TokenBuffer) (ast.Expression, error) {
 	token := buf.Read()
 
-	if token.Type != Bool {
+	if token.Type != True && token.Type != False {
 		return nil, parseError{
 			token.Type,
 			fmt.Sprintf("parseBooleanLiteral() error - %s is not bool", token.Val),

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -376,9 +376,9 @@ func TestParseIntegerLiteral(t *testing.T) {
 
 func TestParseBooleanLiteral(t *testing.T) {
 	tokens := []Token{
-		{Type: Bool, Val: "true"},
-		{Type: Bool, Val: "false"},
-		{Type: Bool, Val: "azzx"},
+		{Type: True, Val: "true"},
+		{Type: False, Val: "false"},
+		{Type: True, Val: "azzx"},
 		{Type: String, Val: "abcdefg"},
 	}
 	tokenBuf := mockTokenBuffer{tokens, 0}
@@ -611,7 +611,8 @@ func TestParseInfixExpression(t *testing.T) {
 }
 
 func TestParseReturnStatement(t *testing.T) {
-	prefixParseFnMap[Bool] = parseBooleanLiteral
+	prefixParseFnMap[True] = parseBooleanLiteral
+	prefixParseFnMap[False] = parseBooleanLiteral
 	prefixParseFnMap[Int] = parseIntegerLiteral
 	infixParseFnMap[Plus] = parseInfixExpression
 	infixParseFnMap[Asterisk] = parseInfixExpression
@@ -619,7 +620,7 @@ func TestParseReturnStatement(t *testing.T) {
 	bufs := [][]Token{
 		{
 			{Type: Return, Val: "return"},
-			{Type: Bool, Val: "true"},
+			{Type: True, Val: "true"},
 			{Type: Eol, Val: "\n"},
 		},
 		{
@@ -698,7 +699,7 @@ func TestParsePrefixExpression(t *testing.T) {
 			&mockTokenBuffer{
 				buf: []Token{
 					{Type: Minus, Val: "!"},
-					{Type: Bool, Val: "true"},
+					{Type: True, Val: "true"},
 					{Type: Eof}},
 				sp: 0,
 			},
@@ -708,7 +709,7 @@ func TestParsePrefixExpression(t *testing.T) {
 			&mockTokenBuffer{
 				buf: []Token{
 					{Type: Minus, Val: "!"},
-					{Type: Bool, Val: "false"},
+					{Type: False, Val: "false"},
 					{Type: Eof}},
 				sp: 0,
 			},
@@ -717,7 +718,8 @@ func TestParsePrefixExpression(t *testing.T) {
 	}
 
 	prefixParseFnMap[Int] = parseIntegerLiteral
-	prefixParseFnMap[Bool] = parseBooleanLiteral
+	prefixParseFnMap[True] = parseBooleanLiteral
+	prefixParseFnMap[False] = parseBooleanLiteral
 
 	for i, tt := range tests {
 		exp, err := parsePrefixExpression(tt.tokenBuffer)

--- a/parse/token.go
+++ b/parse/token.go
@@ -49,7 +49,6 @@ const (
 	Ident    // add, foobar, x, y, ...
 	Int      // 1343456
 	String   // "hello world"
-	Bool     // true, false
 	Function // func
 
 	IntType
@@ -95,7 +94,6 @@ var TokenTypeMap = map[TokenType]string{
 	Ident:  "IDENT",
 	Int:    "INT",
 	String: "STRING",
-	Bool:   "BOOL",
 
 	IntType:    "INT_TYPE",
 	StringType: "STRING_TYPE",

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 
 	"github.com/DE-labtory/koa/opcode"
-	"github.com/stretchr/testify/assert"
 )
 
 func makeTestByteCode(slice ...interface{}) []byte {
@@ -375,7 +374,9 @@ func TestPush(t *testing.T) {
 	}
 
 	for i, item := range stack.items {
-		assert.Equal(t, testExpected[i], item)
+		if testExpected[i] != item {
+			t.Errorf("Stack item is incorrect - expected=%d, got=%d", testExpected[i], item)
+		}
 	}
 }
 


### PR DESCRIPTION
resolved: #131 

* Fix condition of `parseBooleanLiteral`  
* Removed `Bool` token type
* Remove test modules from `vm_test.go`

- [x] Test case