### PR TITLE
test: add test case for parseStatements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,13 @@ module github.com/DE-labtory/koa
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/ethereum/go-ethereum v1.8.21 // indirect
+	github.com/ethereum/go-ethereum v1.8.21
 	github.com/fatih/color v1.7.0
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/testify v1.2.2
+	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
 	golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,5 +14,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
+golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 h1:ku9Kvp2ZBWAz3GyvuUH3UV1bZCd7RxH0Qf1epWfIDKc=
 golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -851,20 +851,20 @@ func TestParseCallExpression(t *testing.T) {
 		expected string
 	}{
 		{
-			function: &ast.StringLiteral{Value: "add"},
-			expected: `function "add"( (1 + 2) )`,
+			function: &ast.Identifier{Value: "add"},
+			expected: `function add( (1 + 2) )`,
 		},
 		{
-			function: &ast.StringLiteral{Value: "testFunc"},
-			expected: `function "testFunc"( "a", "b", 5 )`,
+			function: &ast.Identifier{Value: "testFunc"},
+			expected: `function testFunc( "a", "b", 5 )`,
 		},
 		{
-			function: &ast.StringLiteral{Value: "errorFunc"},
+			function: &ast.Identifier{Value: "errorFunc"},
 			expected: "ASTERISK, prefix parse function not defined",
 		},
 		{
-			function: &ast.StringLiteral{Value: "complexFunc"},
-			expected: `function "complexFunc"( ("a" + "b"), (5 * 3) )`,
+			function: &ast.Identifier{Value: "complexFunc"},
+			expected: `function complexFunc( ("a" + "b"), (5 * 3) )`,
 		},
 	}
 
@@ -933,10 +933,10 @@ func TestParseCallArguments(t *testing.T) {
 		},
 	}
 	tests := []string{
-		`function "testFunction"(  )`,
-		`function "testFunction"( 1 )`,
-		`function "testFunction"( "a", "b", 5 )`,
-		`function "testFunction"( ("a" + "b"), (5 * 3) )`,
+		`function testFunction(  )`,
+		`function testFunction( 1 )`,
+		`function testFunction( "a", "b", 5 )`,
+		`function testFunction( ("a" + "b"), (5 * 3) )`,
 		"ASTERISK, prefix parse function not defined",
 		"ASTERISK, prefix parse function not defined",
 	}
@@ -951,7 +951,7 @@ func TestParseCallArguments(t *testing.T) {
 		}
 
 		mockFn := &ast.CallExpression{
-			Function: &ast.StringLiteral{Value: "testFunction"},
+			Function: &ast.Identifier{Value: "testFunction"},
 		}
 		mockFn.Arguments = exp
 		if exp != nil && mockFn.String() != test {
@@ -1380,6 +1380,7 @@ func TestParseStatement(t *testing.T) {
 		expectedErr  error
 		expectedStmt string
 	}{
+		// tests for IntType
 		{
 			tokens: []Token{
 				{Type: IntType, Val: "int"},
@@ -1389,7 +1390,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: "int val: a, type: IDENT = 1",
+			expectedStmt: "int [IDENT, a] = 1",
 		},
 		{
 			tokens: []Token{
@@ -1402,7 +1403,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: "int val: a, type: IDENT = (1 + 2)",
+			expectedStmt: "int [IDENT, a] = (1 + 2)",
 		},
 		{
 			tokens: []Token{
@@ -1417,7 +1418,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: "int val: a, type: IDENT = (1 + (2 * 3))",
+			expectedStmt: "int [IDENT, a] = (1 + (2 * 3))",
 		},
 		{
 			tokens: []Token{
@@ -1428,8 +1429,10 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `int val: a, type: IDENT = "1"`,
+			expectedStmt: `int [IDENT, a] = "1"`,
 		},
+
+		// tests for StringType
 		{
 			tokens: []Token{
 				{Type: StringType, Val: "string"},
@@ -1439,7 +1442,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `string val: abb, type: IDENT = "do not merge, rebase!"`,
+			expectedStmt: `string [IDENT, abb] = "do not merge, rebase!"`,
 		},
 		{
 			tokens: []Token{
@@ -1450,7 +1453,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `string val: abb, type: IDENT = "hello,*+"`,
+			expectedStmt: `string [IDENT, abb] = "hello,*+"`,
 		},
 		{
 			tokens: []Token{
@@ -1461,8 +1464,10 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `string val: abb, type: IDENT = 1`,
+			expectedStmt: `string [IDENT, abb] = 1`,
 		},
+
+		// tests for BoolType
 		{
 			tokens: []Token{
 				{Type: BoolType, Val: "bool"},
@@ -1472,7 +1477,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `bool val: asdf, type: IDENT = true`,
+			expectedStmt: `bool [IDENT, asdf] = true`,
 		},
 		{
 			tokens: []Token{
@@ -1483,7 +1488,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `bool val: asdf, type: IDENT = false`,
+			expectedStmt: `bool [IDENT, asdf] = false`,
 		},
 		{
 			tokens: []Token{
@@ -1494,8 +1499,10 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `bool val: asdf, type: IDENT = 1`,
+			expectedStmt: `bool [IDENT, asdf] = 1`,
 		},
+
+		// tests for If statement
 		{
 			tokens: []Token{
 				{Type: If, Val: "if"},
@@ -1560,7 +1567,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 }`,
+			expectedStmt: `if ( true ) { int [IDENT, a] = 2 }`,
 		},
 		{
 			tokens: []Token{
@@ -1581,7 +1588,7 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 } else {  }`,
+			expectedStmt: `if ( true ) { int [IDENT, a] = 2 } else {  }`,
 		},
 		{
 			tokens: []Token{
@@ -1607,8 +1614,10 @@ func TestParseStatement(t *testing.T) {
 				{Type: Eol, Val: "\n"},
 			},
 			expectedErr:  nil,
-			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 } else { string val: b, type: IDENT = "hello" }`,
+			expectedStmt: `if ( true ) { int [IDENT, a] = 2 } else { string [IDENT, b] = "hello" }`,
 		},
+
+		// tests for Return statement
 		{
 			tokens: []Token{
 				{Type: Return, Val: "return"},
@@ -1653,6 +1662,8 @@ func TestParseStatement(t *testing.T) {
 			expectedErr:  nil,
 			expectedStmt: `return (function add( 1, 2 ) + (2 * 3))`,
 		},
+
+		// tests for Default
 		{
 			tokens: []Token{
 				{Type: Int, Val: "1"},

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -149,7 +149,7 @@ func TestCurPrecedence(t *testing.T) {
 			expected: PRODUCT,
 		},
 		{
-			expected: LOWEST,
+			expected: CALL,
 		},
 	}
 
@@ -184,7 +184,7 @@ func TestNextPrecedence(t *testing.T) {
 			expected: PRODUCT,
 		},
 		{
-			expected: LOWEST,
+			expected: CALL,
 		},
 	}
 
@@ -1201,44 +1201,79 @@ func TestParseExpression(t *testing.T) {
 }
 
 func TestParseIfStatement(t *testing.T) {
-	prefixParseFnMap[True] = parseBooleanLiteral
-	prefixParseFnMap[False] = parseBooleanLiteral
-	prefixParseFnMap[Int] = parseIntegerLiteral
-	prefixParseFnMap[Ident] = parseIdentifier
-	prefixParseFnMap[String] = parseStringLiteral
-	infixParseFnMap[EQ] = parseInfixExpression
+	initParseFnMap()
+
 	bufs := [][]Token{
 		{
-			{Type: If, Val: "if"}, {Type: Lparen, Val: "("}, {Type: True, Val: "true"}, {Type: Rparen, Val: ")"},
-
-			{Type: Lbrace, Val: "{"}, {Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="},
-			{Type: Int, Val: "0"}, {Type: Eol, Val: "\n"}, {Type: Rbrace, Val: "}"}, {Type: Eol, Val: "\n"},
+			{Type: If, Val: "if"},
+			{Type: Lparen, Val: "("},
+			{Type: True, Val: "true"},
+			{Type: Rparen, Val: ")"},
+			{Type: Lbrace, Val: "{"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Eol, Val: "\n"},
 		},
 		{
-			{Type: If, Val: "if"}, {Type: Lparen, Val: "("}, {Type: Ident, Val: "a"}, {Type: EQ, Val: "=="},
-			{Type: Int, Val: "5"}, {Type: Rparen, Val: ")"},
-
-			{Type: Lbrace, Val: "{"}, {Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="},
-			{Type: Int, Val: "1"}, {Type: Eol, Val: "\n"}, {Type: Rbrace, Val: "}"},
-
-			{Type: Else, Val: "else"}, {Type: Lbrace, Val: "{"}, {Type: StringType, Val: "string"},
-			{Type: Ident, Val: "b"}, {Type: Assign, Val: "="}, {Type: String, Val: "example"}, {Type: Eol, Val: "\n"},
-			{Type: Rbrace, Val: "}"}, {Type: Eol, Val: "\n"},
+			{Type: If, Val: "if"},
+			{Type: Lparen, Val: "("},
+			{Type: Ident, Val: "a"},
+			{Type: EQ, Val: "=="},
+			{Type: Int, Val: "5"},
+			{Type: Rparen, Val: ")"},
+			{Type: Lbrace, Val: "{"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "1"},
+			{Type: Eol, Val: "\n"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Else, Val: "else"},
+			{Type: Lbrace, Val: "{"},
+			{Type: StringType, Val: "string"},
+			{Type: Ident, Val: "b"},
+			{Type: Assign, Val: "="},
+			{Type: String, Val: "example"},
+			{Type: Eol, Val: "\n"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Eol, Val: "\n"},
 		},
 		{
-			{Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="}, {Type: Int, Val: "5"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "5"},
 		},
 		{
-			{Type: If, Val: "if"}, {Type: Lparen, Val: "("}, {Type: True, Val: "true"}, {Type: Rparen, Val: ")"},
-
-			{Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="},
-			{Type: Int, Val: "0"}, {Type: Eol, Val: "\n"}, {Type: Rbrace, Val: "}"}, {Type: Eol, Val: "\n"},
+			{Type: If, Val: "if"},
+			{Type: Lparen, Val: "("},
+			{Type: True, Val: "true"},
+			{Type: Rparen, Val: ")"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Eol, Val: "\n"},
 		},
 		{
-			{Type: If, Val: "if"}, {Type: Lparen, Val: "("}, {Type: True, Val: "true"}, {Type: Rbrace, Val: "}"},
-
-			{Type: Lbrace, Val: "{"}, {Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="},
-			{Type: Int, Val: "0"}, {Type: Eol, Val: "\n"}, {Type: Rbrace, Val: "}"}, {Type: Eol, Val: "\n"},
+			{Type: If, Val: "if"},
+			{Type: Lparen, Val: "("},
+			{Type: True, Val: "true"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Lbrace, Val: "{"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
+			{Type: Rbrace, Val: "}"},
+			{Type: Eol, Val: "\n"},
 		},
 	}
 
@@ -1276,18 +1311,42 @@ func TestParseBlockStatement(t *testing.T) {
 	infixParseFnMap[EQ] = parseInfixExpression
 	bufs := [][]Token{
 		{
-			{Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="}, {Type: Int, Val: "0"}, {Type: Eol, Val: "\n"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
 			{Type: Rbrace, Val: "}"},
 		},
 		{
-			{Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="}, {Type: Int, Val: "0"}, {Type: Eol, Val: "\n"},
-			{Type: StringType, Val: "string"}, {Type: Ident, Val: "b"}, {Type: Assign, Val: "="}, {Type: String, Val: "abc"}, {Type: Eol, Val: "\n"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
+			{Type: StringType, Val: "string"},
+			{Type: Ident, Val: "b"},
+			{Type: Assign, Val: "="},
+			{Type: String, Val: "abc"},
+			{Type: Eol, Val: "\n"},
 			{Type: Rbrace, Val: "}"},
 		},
 		{
-			{Type: IntType, Val: "int"}, {Type: Ident, Val: "a"}, {Type: Assign, Val: "="}, {Type: Int, Val: "0"}, {Type: Eol, Val: "\n"},
-			{Type: StringType, Val: "string"}, {Type: Ident, Val: "b"}, {Type: Assign, Val: "="}, {Type: String, Val: "abc"}, {Type: Eol, Val: "\n"},
-			{Type: BoolType, Val: "bool"}, {Type: Ident, Val: "c"}, {Type: Assign, Val: "="}, {Type: True, Val: "true"}, {Type: Eol, Val: "\n"},
+			{Type: IntType, Val: "int"},
+			{Type: Ident, Val: "a"},
+			{Type: Assign, Val: "="},
+			{Type: Int, Val: "0"},
+			{Type: Eol, Val: "\n"},
+			{Type: StringType, Val: "string"},
+			{Type: Ident, Val: "b"},
+			{Type: Assign, Val: "="},
+			{Type: String, Val: "abc"},
+			{Type: Eol, Val: "\n"},
+			{Type: BoolType, Val: "bool"},
+			{Type: Ident, Val: "c"},
+			{Type: Assign, Val: "="},
+			{Type: True, Val: "true"},
+			{Type: Eol, Val: "\n"},
 			{Type: Rbrace, Val: "}"},
 		},
 	}
@@ -1309,6 +1368,313 @@ func TestParseBlockStatement(t *testing.T) {
 		if exp != nil && exp.String() != test {
 			t.Fatalf("test[%d] - TestParseBlockStatement() wrong result. expected=%s, got=%s",
 				i, test, exp.String())
+		}
+	}
+}
+
+func TestParseStatement(t *testing.T) {
+	initParseFnMap()
+
+	tests := []struct {
+		tokens       []Token
+		expectedErr  error
+		expectedStmt string
+	}{
+		{
+			tokens: []Token{
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "1"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: "int val: a, type: IDENT = 1",
+		},
+		{
+			tokens: []Token{
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "1"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: "int val: a, type: IDENT = (1 + 2)",
+		},
+		{
+			tokens: []Token{
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "1"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: Asterisk, Val: "*"},
+				{Type: Int, Val: "3"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: "int val: a, type: IDENT = (1 + (2 * 3))",
+		},
+		{
+			tokens: []Token{
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: String, Val: "1"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `int val: a, type: IDENT = "1"`,
+		},
+		{
+			tokens: []Token{
+				{Type: StringType, Val: "string"},
+				{Type: Ident, Val: "abb"},
+				{Type: Assign, Val: "="},
+				{Type: String, Val: "do not merge, rebase!"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `string val: abb, type: IDENT = "do not merge, rebase!"`,
+		},
+		{
+			tokens: []Token{
+				{Type: StringType, Val: "string"},
+				{Type: Ident, Val: "abb"},
+				{Type: Assign, Val: "="},
+				{Type: String, Val: "hello,*+"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `string val: abb, type: IDENT = "hello,*+"`,
+		},
+		{
+			tokens: []Token{
+				{Type: StringType, Val: "string"},
+				{Type: Ident, Val: "abb"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "1"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `string val: abb, type: IDENT = 1`,
+		},
+		{
+			tokens: []Token{
+				{Type: BoolType, Val: "bool"},
+				{Type: Ident, Val: "asdf"},
+				{Type: Assign, Val: "="},
+				{Type: True, Val: "true"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `bool val: asdf, type: IDENT = true`,
+		},
+		{
+			tokens: []Token{
+				{Type: BoolType, Val: "bool"},
+				{Type: Ident, Val: "asdf"},
+				{Type: Assign, Val: "="},
+				{Type: False, Val: "false"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `bool val: asdf, type: IDENT = false`,
+		},
+		{
+			tokens: []Token{
+				{Type: BoolType, Val: "bool"},
+				{Type: Ident, Val: "asdf"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "1"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `bool val: asdf, type: IDENT = 1`,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: True, Val: "true"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `if ( true ) {  }`,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: Int, Val: "1"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: EQ, Val: "=="},
+				{Type: Int, Val: "3"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `if ( ((1 + 2) == 3) ) {  }`,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: True, Val: "true"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: Int, Val: "1"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: EQ, Val: "=="},
+				{Type: Int, Val: "3"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  parseError{Int, "invalid token for parsing statement"},
+			expectedStmt: ``,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: True, Val: "true"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "2"},
+				{Type: Eol, Val: "\n"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 }`,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: True, Val: "true"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "2"},
+				{Type: Eol, Val: "\n"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Else, Val: "else"},
+				{Type: Lbrace, Val: "{"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 } else {  }`,
+		},
+		{
+			tokens: []Token{
+				{Type: If, Val: "if"},
+				{Type: Lparen, Val: "("},
+				{Type: True, Val: "true"},
+				{Type: Rparen, Val: ")"},
+				{Type: Lbrace, Val: "{"},
+				{Type: IntType, Val: "int"},
+				{Type: Ident, Val: "a"},
+				{Type: Assign, Val: "="},
+				{Type: Int, Val: "2"},
+				{Type: Eol, Val: "\n"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Else, Val: "else"},
+				{Type: Lbrace, Val: "{"},
+				{Type: StringType, Val: "string"},
+				{Type: Ident, Val: "b"},
+				{Type: Assign, Val: "="},
+				{Type: String, Val: "hello"},
+				{Type: Eol, Val: "\n"},
+				{Type: Rbrace, Val: "}"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `if ( true ) { int val: a, type: IDENT = 2 } else { string val: b, type: IDENT = "hello" }`,
+		},
+		{
+			tokens: []Token{
+				{Type: Return, Val: "return"},
+				{Type: Ident, Val: "asdf"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `return asdf`,
+		},
+		{
+			tokens: []Token{
+				{Type: Return, Val: "return"},
+				{Type: Lparen, Val: "("},
+				{Type: Int, Val: "1"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: Asterisk, Val: "*"},
+				{Type: Int, Val: "3"},
+				{Type: Rparen, Val: ")"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `return (1 + (2 * 3))`,
+		},
+		{
+			tokens: []Token{
+				{Type: Return, Val: "return"},
+				{Type: Lparen, Val: "("},
+				{Type: Ident, Val: "add"},
+				{Type: Lparen, Val: "("},
+				{Type: Int, Val: "1"},
+				{Type: Comma, Val: ","},
+				{Type: Int, Val: "2"},
+				{Type: Rparen, Val: ")"},
+				{Type: Plus, Val: "+"},
+				{Type: Int, Val: "2"},
+				{Type: Asterisk, Val: "*"},
+				{Type: Int, Val: "3"},
+				{Type: Rparen, Val: ")"},
+				{Type: Eol, Val: "\n"},
+			},
+			expectedErr:  nil,
+			expectedStmt: `return (function add( 1, 2 ) + (2 * 3))`,
+		},
+		{
+			tokens: []Token{
+				{Type: Int, Val: "1"},
+			},
+			expectedErr:  parseError{Int, "invalid token for parsing statement"},
+			expectedStmt: ``,
+		},
+	}
+
+	for i, tt := range tests {
+		buf := &mockTokenBuffer{tt.tokens, 0}
+		stmt, err := parseStatement(buf)
+
+		if err != nil && err != tt.expectedErr {
+			t.Errorf(`test[%d] - parseStatement wrong error. expected="%v", got="%v"`,
+				i, tt.expectedErr, err)
+			continue
+		}
+
+		if err == nil && stmt.String() != tt.expectedStmt {
+			t.Errorf(`test[%d] - parseStatement wrong result. expected="%s", got="%s"`,
+				i, tt.expectedStmt, stmt.String())
 		}
 	}
 }


### PR DESCRIPTION
resolved: #153, #121 

details:

* Add test cases for `parseStatements` function
* Fix precedence
* Refactor CallExpression test from `StringLiteral` to `Identifier`
* Fix bugs in `parseIfStatement`
* Fix bugs in `parseCallExpression`

- [x] Test case