### PR TITLE
refactor: Change ast.Program to ast.Contract

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -40,10 +40,10 @@ type Expression interface {
 	produce()
 }
 
-// Represent Program.
-// Program consists of multiple statements.
-type Program struct {
-	Statements []Statement
+// Represent Contract.
+// Contract consists of multiple functions.
+type Contract struct {
+	Functions []*FunctionLiteral
 }
 
 // Represent identifier
@@ -161,6 +161,37 @@ func (is *IfStatement) String() string {
 	}
 	return fmt.Sprintf("if ( %s ) { %s } else { %s }", is.Condition.String(), is.Consequence.String(),
 		is.Alternative.String())
+}
+
+// FunctionLiteral represents function definition
+// e.g. func foo(int a) { ... }
+type FunctionLiteral struct {
+	Name       *Identifier
+	Parameters []*Identifier
+	Body       *BlockStatement
+	ReturnType DataStructure
+}
+
+func (fl *FunctionLiteral) do() {}
+
+// TODO: Add test cases when Type field is added to Identifier
+func (fl *FunctionLiteral) String() string {
+	var out bytes.Buffer
+
+	params := []string{}
+	for _, p := range fl.Parameters {
+		params = append(params, p.String())
+	}
+
+	out.WriteString("func " + fl.Name.String() + "(")
+
+	out.WriteString(strings.Join(params, ", "))
+	out.WriteString(") ")
+	out.WriteString(fl.ReturnType.String() + " {\n")
+	out.WriteString(fl.Body.String() + "\n")
+	out.WriteString("}")
+
+	return out.String()
 }
 
 // Represent block statement

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -149,6 +149,50 @@ func TestBooleanLiteral_String(t *testing.T) {
 	}
 }
 
+// TODO: Add test cases when Type field is added to Identifier
+func TestFunctionLiteral_String(t *testing.T) {
+	tests := []struct {
+		input    FunctionLiteral
+		expected string
+	}{
+		{
+			FunctionLiteral{
+				Name:       &Identifier{Value: "foo"},
+				Parameters: []*Identifier{},
+				Body:       &BlockStatement{},
+				ReturnType: StringType,
+			},
+			`func foo() string {
+
+}`,
+		},
+		{
+			FunctionLiteral{
+				Name:       &Identifier{Value: "foo"},
+				Parameters: []*Identifier{},
+				Body: &BlockStatement{
+					Statements: []Statement{
+						&AssignStatement{
+							Type:     IntType,
+							Variable: Identifier{Value: "a"},
+							Value:    &IntegerLiteral{Value: 1},
+						},
+					},
+				},
+				ReturnType: IntType,
+			},
+			`func foo() int {
+int a = 1
+}`,
+		},
+	}
+
+	for _, tt := range tests {
+		result := tt.input.String()
+		testString(t, result, tt.expected)
+	}
+}
+
 func testString(t *testing.T, got, expected string) {
 	t.Helper()
 	if got != expected {

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -166,22 +166,22 @@ var prefixParseFnMap = map[TokenType]prefixParseFn{}
 var infixParseFnMap = map[TokenType]infixParseFn{}
 
 // Parse function create an abstract syntax tree
-func Parse(buf TokenBuffer) (*ast.Program, error) {
+func Parse(buf TokenBuffer) (*ast.Contract, error) {
 	initParseFnMap()
 
-	prog := &ast.Program{}
-	prog.Statements = []ast.Statement{}
+	contract := &ast.Contract{}
+	contract.Functions = []*ast.FunctionLiteral{}
 
 	for buf.Peek(CURRENT).Type != Eof {
-		stmt, err := parseStatement(buf)
+		fn, err := parseFunctionLiteral(buf)
 		if err != nil {
 			return nil, err
 		}
 
-		prog.Statements = append(prog.Statements, stmt)
+		contract.Functions = append(contract.Functions, fn)
 	}
 
-	return prog, nil
+	return contract, nil
 }
 
 // TODO: Currently there's no parsing function for statement
@@ -562,4 +562,9 @@ func parseBlockStatement(buf TokenBuffer) (*ast.BlockStatement, error) {
 	}
 
 	return block, nil
+}
+
+// TODO: implement me w/ test cases :-)
+func parseFunctionLiteral(buf TokenBuffer) (*ast.FunctionLiteral, error) {
+	return nil, nil
 }

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -25,6 +25,6 @@ func NewCompiler() *Compiler {
 	return nil
 }
 
-func (c *Compiler) Compile(program ast.Program) {
+func (c *Compiler) Compile(program ast.Contract) {
 
 }


### PR DESCRIPTION
resolved: #162, #163 

details:

1. Add FunctionLiteral to ast.go
2. Change Program to Contract and its field 

- [x] Test case