### PR TITLE
Implement comment lexing feature

### DIFF
--- a/parse/lex_internal_test.go
+++ b/parse/lex_internal_test.go
@@ -242,7 +242,6 @@ func (m MockEmitter) emit(t Token) {
 	m.emitFunc(t)
 }
 
-// TODO: LTE, GTE, spaceStateFn, numberStateFn, identifierStateFn case
 func TestLex_defaultStateFn(t *testing.T) {
 
 	//	Bang     // !
@@ -330,7 +329,27 @@ func TestStringStateFn(t *testing.T) {
 		stringStateFn(s, e)
 	}
 }
+func TestCommentStateFn(t *testing.T) {
+	tests := []struct {
+		input string
+	}{
+		{"/commentline"},
+		{"**/"},
+		{"* \n **commentblock** \n */"},
+	}
 
+	for i, test := range tests {
+		s := &state{input: test.input}
+		e := MockEmitter{}
+
+		commentStateFn(s, e)
+
+		if s.next() != eof {
+			t.Errorf("tests[%d] - error", i)
+		}
+
+	}
+}
 func TestErrorStringStateFn(t *testing.T) {
 	tests := []struct {
 		input              string

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -24,8 +24,13 @@ import (
 
 func TestLexer_NextToken(t *testing.T) {
 	input := `
-	contract {
-		func (a int){
+	contract { //lexer does not return this comment as token
+			/*abcdef*/ /*/**/
+			/*
+			lexer does not return this comment as token
+			lexer does not return this comment as token
+			lexer does not return this comment as token */
+			func (a int){
 			3 / 10
 			int a = 5
 			int b = 315 + (5 * 7) / 3 - 10
@@ -43,6 +48,8 @@ second
 		{parse.Eol, "\n"},
 		{parse.Contract, "contract"},
 		{parse.Lbrace, "{"},
+		{parse.Eol, "\n"},
+		{parse.Eol, "\n"},
 		{parse.Eol, "\n"},
 		{parse.Function, "func"},
 		{parse.Lparen, "("},

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -979,7 +979,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"string", "val: a, type: IDENT", `"hello"`,
+			"string", "[IDENT, a]", `"hello"`,
 			nil,
 		},
 		{
@@ -992,7 +992,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"int", "val: myInt, type: IDENT", "1",
+			"int", "[IDENT, myInt]", "1",
 			nil,
 		},
 		{
@@ -1005,7 +1005,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"bool", "val: ddd, type: IDENT", "true",
+			"bool", "[IDENT, ddd]", "true",
 			nil,
 		},
 		{
@@ -1019,7 +1019,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"int", "val: ddd2, type: IDENT", `"iam_string"`,
+			"int", "[IDENT, ddd2]", `"iam_string"`,
 			nil,
 		},
 		{
@@ -1033,7 +1033,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"bool", "val: foo, type: IDENT", `"iam_string"`,
+			"bool", "[IDENT, foo]", `"iam_string"`,
 			nil,
 		},
 		{
@@ -1046,7 +1046,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"bool", "val: foo, type: IDENT", `"iam_string"`,
+			"bool", "[IDENT, foo]", `"iam_string"`,
 			parseError{String, "token is not identifier"},
 		},
 		{
@@ -1058,7 +1058,7 @@ func TestParseAssignStatement(t *testing.T) {
 					{Type: Eof}},
 				sp: 0,
 			},
-			"bool", "val: foo, type: IDENT", `"iam_string"`,
+			"bool", "[IDENT, foo]", `"iam_string"`,
 			parseError{String, "token is not assign"},
 		},
 	}
@@ -1243,8 +1243,8 @@ func TestParseIfStatement(t *testing.T) {
 	}
 
 	tests := []string{
-		"if ( true ) { int val: a, type: IDENT = 0 }",
-		`if ( (a == 5) ) { int val: a, type: IDENT = 1 } else { string val: b, type: IDENT = "example" }`,
+		"if ( true ) { int [IDENT, a] = 0 }",
+		`if ( (a == 5) ) { int [IDENT, a] = 1 } else { string [IDENT, b] = "example" }`,
 		"INT_TYPE, is not a If",
 		"INT_TYPE, is not a Left brace",
 		"RBRACE, is not a Right paren",
@@ -1292,9 +1292,9 @@ func TestParseBlockStatement(t *testing.T) {
 		},
 	}
 	tests := []string{
-		"int val: a, type: IDENT = 0",
-		`int val: a, type: IDENT = 0/string val: b, type: IDENT = "abc"`,
-		`int val: a, type: IDENT = 0/string val: b, type: IDENT = "abc"/bool val: c, type: IDENT = true`,
+		"int [IDENT, a] = 0",
+		`int [IDENT, a] = 0/string [IDENT, b] = "abc"`,
+		`int [IDENT, a] = 0/string [IDENT, b] = "abc"/bool [IDENT, c] = true`,
 	}
 
 	for i, test := range tests {

--- a/parse/token.go
+++ b/parse/token.go
@@ -29,13 +29,13 @@ type Token struct {
 
 func (t Token) String() string {
 	if t.Type == Eol {
-		return fmt.Sprintf("val: End of line, type: Eol")
+		return fmt.Sprintf("[EOL, End of line]")
 	}
 
 	if t.Type == Eof {
-		return fmt.Sprintf("val: End of file, type: Eof")
+		return fmt.Sprintf("[EOF, End of file]")
 	}
-	return fmt.Sprintf("val: %s, type: %s", t.Val, TokenTypeMap[t.Type])
+	return fmt.Sprintf("[%s, %s]", TokenTypeMap[t.Type], t.Val)
 }
 
 // End of file
@@ -92,9 +92,11 @@ const (
 var TokenTypeMap = map[TokenType]string{
 	Illegal: "ILLEGAL",
 
-	Ident:  "IDENT",
-	Int:    "INT",
-	String: "STRING",
+	Ident:    "IDENT",
+	Int:      "INT",
+	String:   "STRING",
+	Function: "FUNCTION",
+	Contract: "CONTRACT",
 
 	IntType:    "INT_TYPE",
 	StringType: "STRING_TYPE",


### PR DESCRIPTION
resolved: #145, #151 
1)Modified defaultStateFn can lex comment ( // , /**/)
2)Change token string format as [TYPE, val] format.
3)fix bug related with TokenTypeMap in token.go

- [ ] Test case