### PR TITLE
refactor: add contract parsing functions & fix makePrefixExpression test cases

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -46,6 +46,21 @@ type Contract struct {
 	Functions []*FunctionLiteral
 }
 
+func (c *Contract) do() {}
+func (c *Contract) String() string {
+	var buf bytes.Buffer
+
+	// start by change line for readability
+	buf.WriteString("\ncontract {\n")
+
+	for _, fn := range c.Functions {
+		buf.WriteString(fn.String() + "\n")
+	}
+	buf.WriteString("}")
+
+	return buf.String()
+}
+
 // Represent identifier
 type Identifier struct {
 	Value string

--- a/parse/parser_test.go
+++ b/parse/parser_test.go
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parse_test


### PR DESCRIPTION
resolved: #122 
details:

1. Add contract parsing functions
2. Fix makePrefixExpression test cases

- [x] Test case