### PR TITLE
Refactor parsePrefixExpression, block some expressions #189

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -379,6 +379,8 @@ func parsePrefixExpression(buf TokenBuffer) (ast.Expression, error) {
 			return nil, parseError{
 				tok.Type,
 				fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", right.String()),
+				tok.Line,
+				tok.Column,
 			}
 		}
 	case ast.Minus:
@@ -387,6 +389,8 @@ func parsePrefixExpression(buf TokenBuffer) (ast.Expression, error) {
 			return nil, parseError{
 				tok.Type,
 				fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", right.String()),
+				tok.Line,
+				tok.Column,
 			}
 		}
 	}

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -18,6 +18,7 @@ package parse
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/DE-labtory/koa/ast"
@@ -367,6 +368,18 @@ func parsePrefixExpression(buf TokenBuffer) (ast.Expression, error) {
 	exp.Right, err = parseExpression(buf, PREFIX)
 	if err != nil {
 		return nil, err
+	}
+	if exp.Operator != operatorMap[Bang] && reflect.TypeOf(exp.Right).String() == "*ast.BooleanLiteral" {
+		return nil, parseError{
+			tok.Type,
+			fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", exp.Right.String()),
+		}
+	}
+	if exp.Operator == operatorMap[Bang] && reflect.TypeOf(exp.Right).String() == "*ast.StringLiteral" {
+		return nil, parseError{
+			tok.Type,
+			fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", exp.Right.String()),
+		}
 	}
 
 	return exp, nil

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -782,14 +782,14 @@ func TestMakePrefixExpression(t *testing.T) {
 				{Type: Minus, Val: "-"},
 				{Type: True, Val: "true"},
 			},
-			expected: "(-true)",
+			expectedErr: errors.New("MINUS, parsePrefixExpression() - Invalid prefix of true"),
 		},
 		{
 			tokens: []Token{
 				{Type: Bang, Val: "!"},
 				{Type: String, Val: "hello"},
 			},
-			expected: `(!"hello")`,
+			expectedErr: errors.New("BANG, parsePrefixExpression() - Invalid prefix of \"hello\""),
 		},
 	}
 
@@ -797,7 +797,7 @@ func TestMakePrefixExpression(t *testing.T) {
 		buf := &mockTokenBuffer{tt.tokens, 0}
 		exp, err := makePrefixExpression(buf)
 
-		if err != nil && err != tt.expectedErr {
+		if err != nil && err.Error() != tt.expectedErr.Error() {
 			t.Errorf(`test[%d] - Wrong error returned expected="%v", got="%v"`,
 				i, tt.expectedErr, err)
 			continue

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -1008,7 +1008,7 @@ func TestMakePrefixExpression(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr: errors.New("MINUS, parsePrefixExpression() - Invalid prefix of true"),
+			expectedErr: errors.New("[line 0, column 0] parsePrefixExpression() - Invalid prefix of true"),
 		},
 		{
 			buf: &mockTokenBuffer{
@@ -1018,7 +1018,7 @@ func TestMakePrefixExpression(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr: errors.New("BANG, parsePrefixExpression() - Invalid prefix of \"hello\""),
+			expectedErr: errors.New("[line 0, column 0] parsePrefixExpression() - Invalid prefix of \"hello\""),
 		},
 	}
 


### PR DESCRIPTION
resolved: #189 

details: I added validation rules to block prefix ‘!‘ is not valid for StringLiteral.
and ‘-’ is also invalid for Boolean.

[task detail...]

1. I added validations to block invalid prefix for some Literals.
2. I fix the TestMakePrefix

- [x] Test case
I fix TestMakePrefix to pass invalid error meesage to indicate blocking following #189 cases.