### PR TITLE
add new operator and fix eol issue

### DIFF
--- a/parse/lex.go
+++ b/parse/lex.go
@@ -160,11 +160,12 @@ type stateFn func(*state, emitter) stateFn
 
 // State has the input(codes) as a string and has the current position and the line.
 type state struct {
-	input string
-	start Pos
-	end   Pos
-	line  int
-	width Pos
+	input      string
+	start      Pos
+	end        Pos
+	line       int
+	width      Pos
+	insertSemi bool //if true, insert semicolon
 }
 
 // Pos represents a byte position in the original input text from which
@@ -258,12 +259,13 @@ func (s *state) isNextToken(next rune) bool {
 	if s.peek() == next {
 		s.next()
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func defaultStateFn(s *state, e emitter) stateFn {
+	insertSemi := false //init
+
 	switch ch := s.next(); {
 	case ch == '!':
 		if s.isNextToken('=') {
@@ -279,17 +281,19 @@ func defaultStateFn(s *state, e emitter) stateFn {
 		}
 	case ch == '+':
 		if s.isNextToken('+') {
+			insertSemi = true
 			e.emit(s.cut(Inc))
 		} else if s.isNextToken('=') {
-			e.emit(s.cut(Plus_assign))
+			e.emit(s.cut(PlusAssign))
 		} else {
 			e.emit(s.cut(Plus))
 		}
 	case ch == '-':
 		if s.isNextToken('-') {
+			insertSemi = true
 			e.emit(s.cut(Dec))
 		} else if s.isNextToken('=') {
-			e.emit(s.cut(Minus_assign))
+			e.emit(s.cut(MinusAssign))
 		} else {
 			e.emit(s.cut(Minus))
 		}
@@ -299,20 +303,20 @@ func defaultStateFn(s *state, e emitter) stateFn {
 			return commentStateFn
 		} else {
 			if s.isNextToken('=') {
-				e.emit(s.cut(Slash_assign))
+				e.emit(s.cut(SlashAssign))
 			} else {
 				e.emit(s.cut(Slash))
 			}
 		}
 	case ch == '*':
 		if s.isNextToken('=') {
-			e.emit(s.cut(Asterisk_assign))
+			e.emit(s.cut(AsteriskAssign))
 		} else {
 			e.emit(s.cut(Asterisk))
 		}
 	case ch == '%':
 		if s.isNextToken('=') {
-			e.emit(s.cut(Mod_assign))
+			e.emit(s.cut(ModAssign))
 		} else {
 			e.emit(s.cut(Mod))
 		}
@@ -329,21 +333,21 @@ func defaultStateFn(s *state, e emitter) stateFn {
 			e.emit(s.cut(GT))
 		}
 	case ch == '&':
-		if s.peek() == '&' {
-			s.next()
+		if s.isNextToken('&') {
 			e.emit(s.cut(Land))
 		}
 	case ch == '|':
-		if s.peek() == '|' {
-			s.next()
+		if s.isNextToken('|') {
 			e.emit(s.cut(Lor))
 		}
 	case ch == ')':
 		e.emit(s.cut(Rparen))
+		insertSemi = true
 	case ch == '(':
 		e.emit(s.cut(Lparen))
 	case ch == '}':
 		e.emit(s.cut(Rbrace))
+		insertSemi = true
 	case ch == '{':
 		e.emit(s.cut(Lbrace))
 	case ch == ',':
@@ -352,12 +356,22 @@ func defaultStateFn(s *state, e emitter) stateFn {
 		s.backup()
 		return stringStateFn
 	case ch == eof:
+		if s.insertSemi {
+			e.emit(s.cut(Semicolon))
+		}
 		e.emit(s.cut(Eof))
 	case isSpace(ch):
 		s.backup()
 		return spaceStateFn
 	case ch == '\n':
-		e.emit(s.cut(Eol))
+		if s.insertSemi {
+			e.emit(s.cut(Semicolon))
+			s.insertSemi = false
+			return defaultStateFn
+		} else {
+			s.acceptRun(" \n\t") //skip whitespace
+			s.cut(Illegal)
+		}
 	case unicode.IsDigit(ch):
 		s.backup()
 		return numberStateFn
@@ -368,6 +382,7 @@ func defaultStateFn(s *state, e emitter) stateFn {
 		e.emit(s.cut(Illegal))
 	}
 
+	s.insertSemi = insertSemi //update
 	return defaultStateFn
 }
 
@@ -400,6 +415,7 @@ func commentStateFn(s *state, e emitter) stateFn {
 // After reading a string, it returns defaultStateFn.
 // string_literal = `"` { unicode_value | byte_value } `"`
 func stringStateFn(s *state, e emitter) stateFn {
+	s.insertSemi = true
 	s.next() //accept '"'
 
 	for s.next() != '"' {
@@ -418,6 +434,7 @@ func stringStateFn(s *state, e emitter) stateFn {
 // After reading Number, it returns DefaultStateFn.
 // number = { decimal_digit }
 func numberStateFn(s *state, e emitter) stateFn {
+	s.insertSemi = true
 	const digits = "0123456789"
 
 	if !s.accept(digits) {
@@ -440,6 +457,7 @@ func numberStateFn(s *state, e emitter) stateFn {
 //
 // identifier = letter { letter | unicode_digit }.
 func identifierStateFn(s *state, e emitter) stateFn {
+	s.insertSemi = true
 	if !(unicode.IsLetter(s.peek()) || s.peek() == '_') {
 		errToken := Token{Illegal, "Invalid function call: identifierStateFn", s.end, s.line}
 		e.emit(errToken)

--- a/parse/lex_internal_test.go
+++ b/parse/lex_internal_test.go
@@ -234,6 +234,27 @@ func TestState_acceptRun(t *testing.T) {
 	}
 }
 
+func TestIsNextToken(t *testing.T) {
+	tests := []struct {
+		input string
+		ok    bool
+	}{
+		{"+a", false},
+		{"+=", false},
+		{"++", true},
+	}
+
+	for i, test := range tests {
+		s := state{
+			input: test.input,
+		}
+		s.next() //got first token
+		if test.ok != s.isNextToken('+') {
+			t.Errorf("tests[%d] - error", i)
+		}
+	}
+}
+
 type MockEmitter struct {
 	emitFunc func(t Token)
 }

--- a/parse/lex_internal_test.go
+++ b/parse/lex_internal_test.go
@@ -205,12 +205,13 @@ func TestState_accept(t *testing.T) {
 
 func TestState_acceptRun(t *testing.T) {
 	// AcceptRun consumes a run of byte from the valid set.
-	valid := "12345abc"
+	valid := "\n\t12345abc"
 
 	tests := []struct {
 		input            string
 		expectedNextRune rune
 	}{
+		{"\t\n0123", '0'},
 		{"0", '0'},
 		{"12345a", eof},
 		{"aaabc123", eof},
@@ -556,12 +557,12 @@ func TestNewTokenBuffer(t *testing.T) {
 		t.Errorf("NewTokenBuffer has wrong lexer")
 	}
 
-	if buf.cur.Type != Eol {
+	if buf.cur.Type != Contract {
 		t.Errorf("NewTokenBuffer has wrong cur token expected=%v, got=%v",
 			Eol, buf.cur.Type)
 	}
 
-	if buf.next.Type != Contract {
+	if buf.next.Type != Lbrace {
 		t.Errorf("NewTokenBuffer has wrong next token expected=%v, got=%v",
 			Contract, buf.next.Type)
 	}

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -39,7 +39,7 @@ func TestLexer_NextToken(t *testing.T) {
 			3 / 10
 			int a = 5
 			int b = 315 + (5 * 7) / 3 - 10
-			<= >= == != = { } , "string"
+			++ -- && || += -= *= /= %= <= >= == != = { } , "string"
 			"First
 second
 		}
@@ -88,6 +88,15 @@ second
 		{parse.Int, "10"},
 		{parse.Eol, "\n"},
 
+		{parse.Inc, "++"},
+		{parse.Dec, "--"},
+		{parse.Land, "&&"},
+		{parse.Lor, "||"},
+		{parse.Plus_assign, "+="},
+		{parse.Minus_assign, "-="},
+		{parse.Asterisk_assign, "*="},
+		{parse.Slash_assign, "/="},
+		{parse.Mod_assign, "%="},
 		{parse.LTE, "<="},
 		{parse.GTE, ">="},
 		{parse.EQ, "=="},

--- a/parse/lex_test.go
+++ b/parse/lex_test.go
@@ -35,42 +35,40 @@ func TestLexer_NextToken(t *testing.T) {
 			lexer does not return this comment as token
 			lexer does not return this comment as token
 			lexer does not return this comment as token */
-			func (a int){
+			func name (a int){
 			3 / 10
 			int a = 5
 			int b = 315 + (5 * 7) / 3 - 10
+			a++ /*comment after semi */
+			a-- //comment after semicolon
+			
+			string this = "abc"
 			++ -- && || += -= *= /= %= <= >= == != = { } , "string"
-			"First
-second
-		}
+			}
 	}
 	`
 
 	tests := []lexTestCase{
-		{parse.Eol, "\n"},
 		{parse.Contract, "contract"},
 		{parse.Lbrace, "{"},
-		{parse.Eol, "\n"},
-		{parse.Eol, "\n"},
-		{parse.Eol, "\n"},
 		{parse.Function, "func"},
+		{parse.Ident, "name"},
 		{parse.Lparen, "("},
 		{parse.Ident, "a"},
 		{parse.IntType, "int"},
 		{parse.Rparen, ")"},
 		{parse.Lbrace, "{"},
 
-		{parse.Eol, "\n"},
 		{parse.Int, "3"},
 		{parse.Slash, "/"},
 		{parse.Int, "10"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
 
 		{parse.IntType, "int"},
 		{parse.Ident, "a"},
 		{parse.Assign, "="},
 		{parse.Int, "5"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
 
 		{parse.IntType, "int"},
 		{parse.Ident, "b"},
@@ -86,17 +84,30 @@ second
 		{parse.Int, "3"},
 		{parse.Minus, "-"},
 		{parse.Int, "10"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
+
+		{parse.Ident, "a"},
+		{parse.Inc, "++"},
+		{parse.Semicolon, "\n"},
+		{parse.Ident, "a"},
+		{parse.Dec, "--"},
+		{parse.Semicolon, "\n"},
+
+		{parse.StringType, "string"},
+		{parse.Ident, "this"},
+		{parse.Assign, "="},
+		{parse.String, "\"abc\""},
+		{parse.Semicolon, "\n"},
 
 		{parse.Inc, "++"},
 		{parse.Dec, "--"},
 		{parse.Land, "&&"},
 		{parse.Lor, "||"},
-		{parse.Plus_assign, "+="},
-		{parse.Minus_assign, "-="},
-		{parse.Asterisk_assign, "*="},
-		{parse.Slash_assign, "/="},
-		{parse.Mod_assign, "%="},
+		{parse.PlusAssign, "+="},
+		{parse.MinusAssign, "-="},
+		{parse.AsteriskAssign, "*="},
+		{parse.SlashAssign, "/="},
+		{parse.ModAssign, "%="},
 		{parse.LTE, "<="},
 		{parse.GTE, ">="},
 		{parse.EQ, "=="},
@@ -106,18 +117,12 @@ second
 		{parse.Rbrace, "}"},
 		{parse.Comma, ","},
 		{parse.String, "\"string\""},
-		{parse.Eol, "\n"},
-
-		{parse.Illegal, "String not terminated"},
-		{parse.String, "\"First"},
-		{parse.Eol, "\n"},
-		{parse.Ident, "second"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
 
 		{parse.Rbrace, "}"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
 		{parse.Rbrace, "}"},
-		{parse.Eol, "\n"},
+		{parse.Semicolon, "\n"},
 		{parse.Eof, ""},
 	}
 
@@ -137,38 +142,40 @@ func TestTokenBuffer(t *testing.T) {
 			lexer does not return this comment as token
 			lexer does not return this comment as token
 			lexer does not return this comment as token */
-			func (a int){
+			func name (a int){
 			3 / 10
 			int a = 5
 			int b = 315 + (5 * 7) / 3 - 10
-			<= >= == != = { } , "string"
-			"First
-second
-		}
+			a++ /*comment after semi */
+			a-- //comment after semicolon
+			
+			string this = "abc"
+			++ -- && || += -= *= /= %= <= >= == != = { } , "string"
+			}
 	}
 	`
 	l := parse.NewLexer(input)
 	buf := parse.NewTokenBuffer(l)
 
 	tok := buf.Read()
-	compareToken(t, 1, tok, lexTestCase{parse.Eol, "\n"})
+	compareToken(t, 1, tok, lexTestCase{parse.Contract, "contract"})
 
 	tok = buf.Read()
-	compareToken(t, 2, tok, lexTestCase{parse.Contract, "contract"})
+	compareToken(t, 2, tok, lexTestCase{parse.Lbrace, "{"})
 
 	tok = buf.Peek(parse.CURRENT)
-	compareToken(t, 3, tok, lexTestCase{parse.Lbrace, "{"})
+	compareToken(t, 3, tok, lexTestCase{parse.Function, "func"})
 
 	tok = buf.Peek(parse.NEXT)
-	compareToken(t, 4, tok, lexTestCase{parse.Eol, "\n"})
+	compareToken(t, 4, tok, lexTestCase{parse.Ident, "name"})
 
 	// this token should be the same with buf.Peek(parse.CURRENT)
 	tok = buf.Read()
-	compareToken(t, 5, tok, lexTestCase{parse.Lbrace, "{"})
+	compareToken(t, 5, tok, lexTestCase{parse.Function, "func"})
 
 	// this token should be the same with buf.Peek(parse.NEXT)
 	tok = buf.Read()
-	compareToken(t, 6, tok, lexTestCase{parse.Eol, "\n"})
+	compareToken(t, 6, tok, lexTestCase{parse.Ident, "name"})
 
 	// invalid peekNumber
 	tok = buf.Peek(3)

--- a/parse/token.go
+++ b/parse/token.go
@@ -65,11 +65,11 @@ const (
 	Slash    // /
 	Mod      // %
 
-	Plus_assign     // +=
-	Minus_assign    // -=
-	Asterisk_assign // *=
-	Slash_assign    // /=
-	Mod_assign      // %=
+	PlusAssign     // +=
+	MinusAssign    // -=
+	AsteriskAssign // *=
+	SlashAssign    // /=
+	ModAssign      // %=
 
 	Land // &&
 	Lor  // ||
@@ -97,6 +97,7 @@ const (
 	Return // return
 	Eof    // end of file
 	Eol    // end of line
+	Semicolon
 )
 
 // TokenTypeMap mapping TokenType with its
@@ -122,11 +123,11 @@ var TokenTypeMap = map[TokenType]string{
 	Slash:    "SLASH",
 	Mod:      "MOD",
 
-	Plus_assign:     "PLUS_ASSIGN",
-	Minus_assign:    "MINUS_ASSIGN",
-	Asterisk_assign: "ASTERISK_ASSIGN",
-	Slash_assign:    "SLASH_ASSIGN",
-	Mod_assign:      "MOD_ASSIGN",
+	PlusAssign:     "PLUS_ASSIGN",
+	MinusAssign:    "MINUS_ASSIGN",
+	AsteriskAssign: "ASTERISK_ASSIGN",
+	SlashAssign:    "SLASH_ASSIGN",
+	ModAssign:      "MOD_ASSIGN",
 
 	Land: "LAND",
 	Lor:  "LOR",
@@ -153,8 +154,9 @@ var TokenTypeMap = map[TokenType]string{
 	Else:   "ELSE",
 	Return: "RETURN",
 
-	Eof: "EOF",
-	Eol: "EOL",
+	Eof:       "EOF",
+	Eol:       "EOL",
+	Semicolon: "SEMICOLON",
 }
 
 var keywords = map[string]TokenType{

--- a/parse/token.go
+++ b/parse/token.go
@@ -65,6 +65,17 @@ const (
 	Slash    // /
 	Mod      // %
 
+	Plus_assign     // +=
+	Minus_assign    // -=
+	Asterisk_assign // *=
+	Slash_assign    // /=
+	Mod_assign      // %=
+
+	Land // &&
+	Lor  // ||
+	Inc  // ++
+	Dec  //--
+
 	LT     // <
 	GT     // >
 	LTE    // <=
@@ -110,6 +121,17 @@ var TokenTypeMap = map[TokenType]string{
 	Asterisk: "ASTERISK",
 	Slash:    "SLASH",
 	Mod:      "MOD",
+
+	Plus_assign:     "PLUS_ASSIGN",
+	Minus_assign:    "MINUS_ASSIGN",
+	Asterisk_assign: "ASTERISK_ASSIGN",
+	Slash_assign:    "SLASH_ASSIGN",
+	Mod_assign:      "MOD_ASSIGN",
+
+	Land: "LAND",
+	Lor:  "LOR",
+	Inc:  "INC",
+	Dec:  "DEC",
 
 	LT:     "LT",
 	GT:     "GT",


### PR DESCRIPTION
resolved: #144 #138 #186

1. add new operator and refactoring defaultStateFn
+=, -=, *=, /=, %=, &&, ||, ++, --
2. Add insertSemi val and fix eol issue

add insertSemi value in stateFn and solve EOL issue in lexer.
now lexer don't return EOL token.
semicolon added when final token at end of line(\n) is

- Number, String, Ident
- ++, --
- } )
it consume every comment block or line
- [ ] Test case