### PR TITLE
Add type checker for assignment statement

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -49,6 +49,16 @@ var datastructureMap = map[TokenType]ast.DataStructure{
 	VoidType:   ast.VoidType,
 }
 
+// identifierTypeMap maps TokenType and TokenType.
+// It is used checking identifier and assigned check
+// for example, int a = "1234" will be failed.
+var identifierTypeMap = map[TokenType]ast.DataStructure{
+	Int:    ast.IntType,
+	True:   ast.BoolType,
+	False:  ast.BoolType,
+	String: ast.StringType,
+}
+
 // precedence determine which token is going to be grouped first when
 // parsing expression with Pratt Parsing.
 //
@@ -647,6 +657,15 @@ func parseAssignStatement(buf TokenBuffer) (*ast.AssignStatement, error) {
 			assign.Column,
 		}
 	}
+	peekTok := buf.Peek(CURRENT)
+	if isPrimitiveType(peekTok.Type) && identifierTypeMap[peekTok.Type] != stmt.Type {
+		return nil, parseError{
+			peekTok.Type,
+			fmt.Sprintf("type mismatch: expected [%s], buf got [%s]", ds.String(), TokenTypeMap[peekTok.Type]),
+			peekTok.Line,
+			peekTok.Column,
+		}
+	}
 
 	exp, err := parseExpression(buf, LOWEST)
 	if err != nil {
@@ -822,4 +841,8 @@ func parseExpressionStatement(buf TokenBuffer) (*ast.ExpressionStatement, error)
 
 	stmt.Expr = exp
 	return stmt, nil
+}
+
+func isPrimitiveType(t TokenType) bool {
+	return t == Int || t == True || t == False || t == String
 }

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -1811,9 +1811,14 @@ func TestParseAssignStatement(t *testing.T) {
 				sp: 0,
 			},
 			"int",
-			"[IDENT, ddd2]",
-			`"iam_string"`,
-			nil,
+			"",
+			"",
+			parseError{
+				String,
+				"type mismatch: expected [int], buf got [STRING]",
+				0,
+				0,
+			},
 		},
 		{
 			// type mismatch tc - bool foo = "iam_string"
@@ -1827,9 +1832,14 @@ func TestParseAssignStatement(t *testing.T) {
 				sp: 0,
 			},
 			"bool",
-			"[IDENT, foo]",
-			`"iam_string"`,
-			nil,
+			"",
+			"",
+			parseError{
+				String,
+				"type mismatch: expected [bool], buf got [STRING]",
+				0,
+				0,
+			},
 		},
 		{
 			&mockTokenBuffer{
@@ -1842,8 +1852,8 @@ func TestParseAssignStatement(t *testing.T) {
 				sp: 0,
 			},
 			"bool",
-			"[IDENT, foo]",
-			`"iam_string"`,
+			"",
+			"",
 			parseError{
 				String,
 				"expected [IDENT], but got [STRING]",
@@ -1861,14 +1871,32 @@ func TestParseAssignStatement(t *testing.T) {
 				sp: 0,
 			},
 			"bool",
-			"[IDENT, foo]",
-			`"iam_string"`,
+			"",
+			"",
 			parseError{
 				String,
 				"expected [ASSIGN], but got [STRING]",
 				0,
 				0,
 			},
+		},
+		{
+			&mockTokenBuffer{
+				buf: []Token{
+					{Type: BoolType, Val: "int"},
+					{Type: Ident, Val: "ddd"},
+					{Type: Assign, Val: "="},
+					{Type: Ident, Val: "add"},
+					{Type: Lparen, Val: "("},
+					{Type: Ident, Val: "a"},
+					{Type: Rparen, Val: ")"},
+					{Type: Eof}},
+				sp: 0,
+			},
+			"bool",
+			"[IDENT, ddd]",
+			"function add( a )",
+			nil,
 		},
 	}
 
@@ -2336,8 +2364,13 @@ func TestParseStatement(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr:  nil,
-			expectedStmt: `int [IDENT, a] = "1"`,
+			expectedErr: parseError{
+				String,
+				"type mismatch: expected [int], buf got [STRING]",
+				0,
+				0,
+			},
+			expectedStmt: "",
 		},
 
 		// tests for StringType
@@ -2380,8 +2413,13 @@ func TestParseStatement(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr:  nil,
-			expectedStmt: `string [IDENT, abb] = 1`,
+			expectedErr: parseError{
+				Int,
+				"type mismatch: expected [string], buf got [INT]",
+				0,
+				0,
+			},
+			expectedStmt: "",
 		},
 
 		// tests for BoolType
@@ -2424,8 +2462,13 @@ func TestParseStatement(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr:  nil,
-			expectedStmt: `bool [IDENT, asdf] = 1`,
+			expectedErr: parseError{
+				Int,
+				"type mismatch: expected [bool], buf got [INT]",
+				0,
+				0,
+			},
+			expectedStmt: "",
 		},
 
 		// tests for If statement


### PR DESCRIPTION
Add type checker in parseAssignmentState()

For example, if we input below sentence,
int a = "abcd"
This should fail unconditionally, but out parser was not.

So I added logic that compare identifier and assigner's type.