### PR TITLE
feat: skel adding scope to parser

### DIFF
--- a/symbol/scope.go
+++ b/symbol/scope.go
@@ -18,7 +18,6 @@ package symbol
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"sort"
 )
@@ -45,16 +44,16 @@ type Scope struct {
 // Getter return's variable's scope.
 // If a scope doesn't have a variable,
 // Program will search in outer scope.
-func (s *Scope) Get(name string) (Symbol, error) {
+func (s *Scope) Get(name string) Symbol {
 	var scope = s
 	for scope != nil {
 		obj, ok := scope.store[name]
 		if ok {
-			return obj, nil
+			return obj
 		}
 		scope = scope.outer
 	}
-	return nil, errors.New(fmt.Sprintf("%s is not defined", name))
+	return nil
 }
 
 // Setter set a variable to target scope's map

--- a/symbol/scope_test.go
+++ b/symbol/scope_test.go
@@ -17,7 +17,6 @@
 package symbol
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/DE-labtory/koa/ast"
@@ -52,7 +51,6 @@ func TestScopeGetter(t *testing.T) {
 		scope       Scope
 		want        string
 		expectedSym Symbol
-		expectedErr error
 	}{
 		{
 			Scope{
@@ -64,7 +62,6 @@ func TestScopeGetter(t *testing.T) {
 			},
 			"a",
 			&Integer{&ast.Identifier{Value: "a"}},
-			nil,
 		},
 		{
 			Scope{
@@ -81,7 +78,6 @@ func TestScopeGetter(t *testing.T) {
 			},
 			"c",
 			&String{&ast.Identifier{Value: "c"}},
-			nil,
 		},
 		{
 			Scope{
@@ -93,21 +89,21 @@ func TestScopeGetter(t *testing.T) {
 			},
 			"c",
 			nil,
-			errors.New("c is not defined"),
 		},
 	}
 
 	for i, test := range tests {
-		sym, err := test.scope.Get(test.want)
+		sym := test.scope.Get(test.want)
 		if sym != nil && test.expectedSym.String() != sym.String() {
 			t.Fatalf("test[%d] testScopeGetter() returns invalid symbol.\n"+
 				"expected=%s\n"+
 				"got=%s", i, test.expectedSym.String(), sym.String())
 		}
-		if err != nil && err.Error() != test.expectedErr.Error() {
-			t.Fatalf("test[%d] testScopeGetter() returns invalid error.\n"+
-				"expected=%s\n"+
-				"got=%s", i, test.expectedErr.Error(), err.Error())
+
+		if sym != nil && test.expectedSym == nil {
+			t.Fatalf("test[%d] testScopeGetter() returns invalid symbol.\n"+
+				"expected=nil\n"+
+				"got=%s", i, sym.String())
 		}
 	}
 }
@@ -146,13 +142,13 @@ func TestScopeSetter(t *testing.T) {
 
 	for i, test := range tests {
 		symbol := test.Scope.Set(test.Name, test.Symbol)
-		if symbol != test.Symbol {
+		if symbol.String() != test.Symbol.String() {
 			t.Fatalf("test[%d] - TestScopeSetter() wrong result.\n"+
 				"expected=%s\n"+
 				"got=%s", i, test.Symbol.String(), symbol.String())
 		}
 
-		if _, err := test.Scope.Get(test.Name); err != nil {
+		if sym := test.Scope.Get(test.Name); sym.String() != test.Symbol.String() {
 			t.Fatalf("test[%d] - TestScopeSetter() must set in scope store", i)
 		}
 	}

--- a/symbol/symbol.go
+++ b/symbol/symbol.go
@@ -80,7 +80,7 @@ func (s *String) String() string {
 // Name represents function's name.
 // Scope represents function value's scope.
 type Function struct {
-	name  string
+	Name  string
 	Scope *Scope
 }
 
@@ -89,5 +89,5 @@ func (f *Function) Type() SymbolType {
 }
 
 func (f *Function) String() string {
-	return fmt.Sprintf("func %s", f.name)
+	return fmt.Sprintf("func %s", f.Name)
 }


### PR DESCRIPTION
resolved: #239 

details:

1. feat: skel adding scope to parsing functions with its helper fns
2. feat: add updateScopeSymbol to parseFunctionLiteral w/ tcs
3. refactor: extract parseFunctionParameter function

- [x] Test case