### PR TITLE
Add abi/type proto

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -30,20 +30,20 @@ func TestNew(t *testing.T) {
 		"arguments" : [
 			{
 				"name" : "first",
-				"type" : "int256"
+				"type" : "int64"
 			},
 			{
 				"name" : "second",
 				"type" : "string"
 			},
 			{
-				"name" : "third",
-				"type" : "byte"
+				"name" : "true",
+				"type" : "bool"
 			}
 		],
 		"output" : {
 			"name" : "returnValue",
-			"type" : "int256"
+			"type" : "int64"
 		}
 	},
 	{
@@ -51,20 +51,20 @@ func TestNew(t *testing.T) {
 		"arguments" : [
 			{
 				"name" : "first",
-				"type" : "int256"
+				"type" : "int64"
 			},
 			{
 				"name" : "second",
 				"type" : "string"
 			},
 			{
-				"name" : "third",
-				"type" : "byte"
+				"name" : "false",
+				"type" : "bool"
 			}
 		],
 		"output" : {
 			"name" : "returnValue",
-			"type" : "int256"
+			"type" : "int64"
 		}
 	}
 ]

--- a/abi/type.go
+++ b/abi/type.go
@@ -16,9 +16,35 @@
 
 package abi
 
+import (
+	"fmt"
+)
+
+type ParamType string
+
+const (
+	Integer64 ParamType = "int64"
+	Boolean   ParamType = "bool"
+	String    ParamType = "string"
+)
+
 type Type struct {
+	Type ParamType
 }
 
-func NewType() Type {
-	return Type{}
+func NewType(paramType string) (Type, error) {
+	typ := Type{}
+
+	switch paramType {
+	case "int64":
+		typ.Type = Integer64
+	case "bool":
+		typ.Type = Boolean
+	case "string":
+		typ.Type = String
+	default:
+		return Type{}, fmt.Errorf("unsupported arg type: %s", paramType)
+	}
+
+	return typ, nil
 }

--- a/abi/type_test.go
+++ b/abi/type_test.go
@@ -1,1 +1,54 @@
-package abi
+/*
+ * Copyright 2018 De-labtory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package abi_test
+
+import (
+	"testing"
+
+	"github.com/DE-labtory/koa/abi"
+)
+
+func TestNewType(t *testing.T) {
+	tests := []struct {
+		Type         string
+		expectedType abi.ParamType
+	}{
+		{
+			Type:         "int64",
+			expectedType: abi.Integer64,
+		},
+		{
+			Type:         "bool",
+			expectedType: abi.Boolean,
+		},
+		{
+			Type:         "string",
+			expectedType: abi.String,
+		},
+	}
+
+	for _, test := range tests {
+		Type, err := abi.NewType(test.Type)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if Type.Type != test.expectedType {
+			t.Errorf("Invalid Type : %s", Type.Type)
+		}
+	}
+}


### PR DESCRIPTION
resolved: #255

details:
Add abi/type proto

Now, we use jsut `int`, `bool`, `string`.
and `int` is basically `int64` because the maximum value of our stack is int64.

It is really basic Implementation what we need right now!
I considered we can add something new type(koa defined) later

- [ ] Test case