### PR TITLE
Implements scope in block statement

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -369,8 +369,8 @@ func parseStatement(buf TokenBuffer) (ast.Statement, error) {
 		return parseIfStatement(buf)
 	case Return:
 		return parseReturnStatement(buf)
-	case Lbrace:
-		return parseBlockStatement(buf)
+	case Ident:
+		return parseReassignStatement(buf)
 	default:
 		return parseExpressionStatement(buf)
 	}
@@ -784,6 +784,8 @@ func parseReassignStatement(buf TokenBuffer) (ast.Statement, error) {
 	}
 	stmt.Value = exp
 
+	consumeSemi(buf)
+
 	return stmt, nil
 }
 
@@ -891,6 +893,8 @@ func parseBlockStatement(buf TokenBuffer) (*ast.BlockStatement, error) {
 		return nil, err
 	}
 
+	enterScope()
+
 	block := &ast.BlockStatement{}
 	curToken := buf.Peek(CURRENT)
 
@@ -908,6 +912,8 @@ func parseBlockStatement(buf TokenBuffer) (*ast.BlockStatement, error) {
 	if curTokenIs(buf, Rbrace) {
 		buf.Read()
 	}
+
+	leaveScope()
 
 	return block, nil
 }

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -206,6 +206,16 @@ func (e PrefixError) Error() string {
 		e.source.Line, e.source.Column, e.right.String())
 }
 
+// NotExistSymError occur when there is no target symbol
+type NotExistSymError struct {
+	source Token
+}
+
+func (e NotExistSymError) Error() string {
+	return fmt.Sprintf("[lint %d, column %d] symbol [%s] is not exist",
+		e.source.Line, e.source.Column, e.source.Val)
+}
+
 type (
 	prefixParseFn func(TokenBuffer) (ast.Expression, error)
 	infixParseFn  func(TokenBuffer, ast.Expression) (ast.Expression, error)
@@ -497,9 +507,9 @@ func parseIdentifier(buf TokenBuffer) (ast.Expression, error) {
 		return nil, ExpectError{token, Ident}
 	}
 
-	// TODO: check whether variable name exist,
-	// TODO: but do not update symbol table in this case
-	// TODO: if not, return error
+	if exist := scope.Get(token.Val); exist == nil {
+		return nil, NotExistSymError{token}
+	}
 
 	return &ast.Identifier{Value: token.Val}, nil
 }


### PR DESCRIPTION
resolved: #269, #270

1. Implements parseReassignStatmenet and tcs
2. Implements scoping in block statement

- [x] Test case