### PR TITLE
Add limitation to parsing prefix function

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -195,6 +195,17 @@ func (e DupSymError) Error() string {
 		e.source.Line, e.source.Column, e.source.Val)
 }
 
+// prefixError occur when there is invalid prefix type
+type PrefixError struct {
+	source Token
+	right  ast.Expression
+}
+
+func (e PrefixError) Error() string {
+	return fmt.Sprintf("[line %d, columnd %d] Invalid prefix of %s",
+		e.source.Line, e.source.Column, e.right.String())
+}
+
 type (
 	prefixParseFn func(TokenBuffer) (ast.Expression, error)
 	infixParseFn  func(TokenBuffer, ast.Expression) (ast.Expression, error)
@@ -454,18 +465,18 @@ func parsePrefixExpression(buf TokenBuffer) (ast.Expression, error) {
 	switch op {
 	case ast.Bang:
 		switch right.(type) {
-		case *ast.StringLiteral:
-			return nil, Error{
+		case *ast.StringLiteral, *ast.IntegerLiteral:
+			return nil, PrefixError{
 				token,
-				fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", right.String()),
+				right,
 			}
 		}
 	case ast.Minus:
 		switch right.(type) {
-		case *ast.BooleanLiteral:
-			return nil, Error{
+		case *ast.BooleanLiteral, *ast.StringLiteral:
+			return nil, PrefixError{
 				token,
-				fmt.Sprintf("parsePrefixExpression() - Invalid prefix of %s", right.String()),
+				right,
 			}
 		}
 	}

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -1145,7 +1145,10 @@ func TestMakePrefixExpression(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr: errors.New("[line 0, column 0] [MINUS] parsePrefixExpression() - Invalid prefix of true"),
+			expectedErr: PrefixError{
+				Token{Type: Minus, Val: "-"},
+				&ast.BooleanLiteral{Value: true},
+			},
 		},
 		{
 			buf: &mockTokenBuffer{
@@ -1155,7 +1158,23 @@ func TestMakePrefixExpression(t *testing.T) {
 				},
 				0,
 			},
-			expectedErr: errors.New("[line 0, column 0] [BANG] parsePrefixExpression() - Invalid prefix of hello"),
+			expectedErr: PrefixError{
+				Token{Type: Bang, Val: "!"},
+				&ast.StringLiteral{Value: "hello"},
+			},
+		},
+		{
+			buf: &mockTokenBuffer{
+				[]Token{
+					{Type: Bang, Val: "!"},
+					{Type: Int, Val: "3"},
+				},
+				0,
+			},
+			expectedErr: PrefixError{
+				Token{Type: Bang, Val: "!"},
+				&ast.IntegerLiteral{Value: 3},
+			},
 		},
 	}
 


### PR DESCRIPTION
Add limitation to parsing prefix function
like below
```go
!a
-a   // a is string
!3
```

- [x] Test case