### PR TITLE
fix: change Identifier field Value to Name

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -63,11 +63,12 @@ func (c *Contract) String() string {
 
 // Represent identifier
 type Identifier struct {
-	Value string
+	// Name is the identifier's **name** not the value of Identifier
+	Name string
 }
 
 func (i *Identifier) String() string {
-	return i.Value
+	return i.Name
 }
 
 func (i *Identifier) produce() {}
@@ -149,7 +150,7 @@ func (as *AssignStatement) do() {}
 func (as *AssignStatement) String() string {
 	var out bytes.Buffer
 	out.WriteString(as.Type.String() + " ")
-	out.WriteString(as.Variable.Value + " = ")
+	out.WriteString(as.Variable.Name + " = ")
 	out.WriteString(as.Value.String())
 	return out.String()
 }

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -10,7 +10,7 @@ func TestAssignStatement_String(t *testing.T) {
 		{
 			input: AssignStatement{
 				Type:     IntType,
-				Variable: Identifier{Value: "a"},
+				Variable: Identifier{Name: "a"},
 				Value:    &IntegerLiteral{Value: 1},
 			},
 			expected: "int a = 1",
@@ -18,7 +18,7 @@ func TestAssignStatement_String(t *testing.T) {
 		{
 			input: AssignStatement{
 				Type:     BoolType,
-				Variable: Identifier{Value: "asdf"},
+				Variable: Identifier{Name: "asdf"},
 				Value:    &StringLiteral{Value: "hello, world"},
 			},
 			// type mismatch is not considered here
@@ -27,7 +27,7 @@ func TestAssignStatement_String(t *testing.T) {
 		{
 			input: AssignStatement{
 				Type:     StringType,
-				Variable: Identifier{Value: "ff"},
+				Variable: Identifier{Name: "ff"},
 				Value:    &BooleanLiteral{Value: true},
 			},
 			// type mismatch is not considered here
@@ -47,23 +47,23 @@ func TestIdentifier_String(t *testing.T) {
 		expected string
 	}{
 		{
-			input:    Identifier{Value: "a"},
+			input:    Identifier{Name: "a"},
 			expected: "a",
 		},
 		{
-			input:    Identifier{Value: "zcf"},
+			input:    Identifier{Name: "zcf"},
 			expected: "zcf",
 		},
 		{
-			input:    Identifier{Value: "zcf asdf"},
+			input:    Identifier{Name: "zcf asdf"},
 			expected: "zcf asdf",
 		},
 		{
-			input:    Identifier{Value: "123"},
+			input:    Identifier{Name: "123"},
 			expected: "123",
 		},
 		{
-			input:    Identifier{Value: ""},
+			input:    Identifier{Name: ""},
 			expected: "",
 		},
 	}
@@ -156,7 +156,7 @@ func TestFunctionLiteral_String(t *testing.T) {
 	}{
 		{
 			FunctionLiteral{
-				Name:       &Identifier{Value: "foo"},
+				Name:       &Identifier{Name: "foo"},
 				Parameters: []*ParameterLiteral{},
 				Body:       &BlockStatement{},
 				ReturnType: StringType,
@@ -167,13 +167,13 @@ func TestFunctionLiteral_String(t *testing.T) {
 		},
 		{
 			FunctionLiteral{
-				Name:       &Identifier{Value: "foo"},
+				Name:       &Identifier{Name: "foo"},
 				Parameters: []*ParameterLiteral{},
 				Body: &BlockStatement{
 					Statements: []Statement{
 						&AssignStatement{
 							Type:     IntType,
-							Variable: Identifier{Value: "a"},
+							Variable: Identifier{Name: "a"},
 							Value:    &IntegerLiteral{Value: 1},
 						},
 					},
@@ -200,7 +200,7 @@ func TestReassignStatement_String(t *testing.T) {
 		{
 			input: ReassignStatement{
 				Variable: &Identifier{
-					Value: "foo",
+					Name: "foo",
 				},
 				Value: &BooleanLiteral{
 					Value: true,
@@ -211,7 +211,7 @@ func TestReassignStatement_String(t *testing.T) {
 		{
 			input: ReassignStatement{
 				Variable: &Identifier{
-					Value: "foo",
+					Name: "foo",
 				},
 				Value: &PrefixExpression{
 					Operator: Minus,
@@ -225,7 +225,7 @@ func TestReassignStatement_String(t *testing.T) {
 		{
 			input: ReassignStatement{
 				Variable: &Identifier{
-					Value: "foo",
+					Name: "foo",
 				},
 				Value: &InfixExpression{
 					Left: &StringLiteral{

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -218,11 +218,11 @@ func updateScopeSymbol(ident Token, keyword Token) error {
 
 	switch keyword.Type {
 	case IntType:
-		scope.Set(ident.Val, &symbol.Integer{Name: &ast.Identifier{Value: ident.Val}})
+		scope.Set(ident.Val, &symbol.Integer{Name: &ast.Identifier{Name: ident.Val}})
 	case BoolType:
-		scope.Set(ident.Val, &symbol.Boolean{Name: &ast.Identifier{Value: ident.Val}})
+		scope.Set(ident.Val, &symbol.Boolean{Name: &ast.Identifier{Name: ident.Val}})
 	case StringType:
-		scope.Set(ident.Val, &symbol.String{Name: &ast.Identifier{Value: ident.Val}})
+		scope.Set(ident.Val, &symbol.String{Name: &ast.Identifier{Name: ident.Val}})
 	case Function:
 		scope.Set(ident.Val, &symbol.Function{Name: ident.Val})
 	default:
@@ -488,7 +488,7 @@ func parseIdentifier(buf TokenBuffer) (ast.Expression, error) {
 	// TODO: but do not update symbol table in this case
 	// TODO: if not, return error
 
-	return &ast.Identifier{Value: token.Val}, nil
+	return &ast.Identifier{Name: token.Val}, nil
 }
 
 // parseIntegerLiteral parse integer literal.
@@ -554,7 +554,7 @@ func parseFunctionLiteral(buf TokenBuffer) (*ast.FunctionLiteral, error) {
 		return nil, err
 	}
 
-	lit.Name = &ast.Identifier{Value: token.Val}
+	lit.Name = &ast.Identifier{Name: token.Val}
 
 	if err = expectNext(buf, Lparen); err != nil {
 		return nil, err
@@ -643,7 +643,7 @@ func parseFunctionParameter(buf TokenBuffer) (*ast.ParameterLiteral, error) {
 	// TODO: if not, return error
 
 	ident := &ast.ParameterLiteral{
-		Identifier: &ast.Identifier{Value: token.Val},
+		Identifier: &ast.Identifier{Name: token.Val},
 	}
 
 	token = buf.Read()
@@ -714,7 +714,7 @@ func parseAssignStatement(buf TokenBuffer) (*ast.AssignStatement, error) {
 	}
 
 	stmt.Variable = ast.Identifier{
-		Value: token.Val,
+		Name: token.Val,
 	}
 
 	if err := expectNext(buf, Assign); err != nil {
@@ -872,7 +872,7 @@ func parseExpressionStatement(buf TokenBuffer) (*ast.ExpressionStatement, error)
 		}
 	}
 
-	ident := &ast.Identifier{Value: token.Val}
+	ident := &ast.Identifier{Name: token.Val}
 	exp, err := parseCallExpression(buf, ident)
 	if err != nil {
 		return nil, err

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -479,7 +479,7 @@ func TestParseIdentifier(t *testing.T) {
 				0,
 			},
 			expected: &ast.Identifier{
-				Value: "ADD",
+				Name: "ADD",
 			},
 			expectedErrs: nil,
 		},
@@ -551,7 +551,7 @@ func TestParseIdentifier(t *testing.T) {
 			if test.expected != nil {
 				t.Fatalf("test[%d] - wrong result. expected=%s, got=%s", i, test.expected.String(), exp.String())
 			}
-		case &ast.Identifier{Value: exp.String()}:
+		case &ast.Identifier{Name: exp.String()}:
 			if exp.String() != exp.String() {
 				t.Fatalf("test[%d] - wrong result. expected=%s, got=%s", i, test.expected.String(), exp.String())
 			}
@@ -1654,7 +1654,7 @@ func TestParsePrefixExpression(t *testing.T) {
 		}
 
 		if expression.Right.String() != tt.expectedRight {
-			t.Errorf("tests[%d] - Value is not %s but got %s",
+			t.Errorf("tests[%d] - Name is not %s but got %s",
 				i, tt.expectedRight, expression.Right.String())
 		}
 	}
@@ -1679,7 +1679,7 @@ func TestParseCallExpression(t *testing.T) {
 				},
 				0,
 			},
-			function:    &ast.Identifier{Value: "add"},
+			function:    &ast.Identifier{Name: "add"},
 			expected:    `function add( (1 + 2) )`,
 			expectedErr: nil,
 		},
@@ -1696,7 +1696,7 @@ func TestParseCallExpression(t *testing.T) {
 				},
 				0,
 			},
-			function:    &ast.Identifier{Value: "testFunc"},
+			function:    &ast.Identifier{Name: "testFunc"},
 			expected:    `function testFunc( a, b, 5 )`,
 			expectedErr: nil,
 		},
@@ -1713,7 +1713,7 @@ func TestParseCallExpression(t *testing.T) {
 				},
 				0,
 			},
-			function: &ast.Identifier{Value: "errorFunc"},
+			function: &ast.Identifier{Name: "errorFunc"},
 			expected: "",
 			expectedErr: Error{
 				Token{Type: Asterisk},
@@ -1735,7 +1735,7 @@ func TestParseCallExpression(t *testing.T) {
 				},
 				0,
 			},
-			function:    &ast.Identifier{Value: "complexFunc"},
+			function:    &ast.Identifier{Name: "complexFunc"},
 			expected:    `function complexFunc( (a + b), (5 * 3) )`,
 			expectedErr: nil,
 		},
@@ -1862,7 +1862,7 @@ func TestParseCallArguments(t *testing.T) {
 		}
 
 		mockFn := &ast.CallExpression{
-			Function: &ast.Identifier{Value: "testFunction"},
+			Function: &ast.Identifier{Name: "testFunction"},
 		}
 		mockFn.Arguments = exp
 		if exp != nil && mockFn.String() != test.expected {
@@ -2116,7 +2116,7 @@ func TestParseAssignStatement(t *testing.T) {
 		{
 			func() *symbol.Scope {
 				scope := symbol.NewScope()
-				scope.Set("ddd", &symbol.String{Name: &ast.Identifier{Value: "asdf"}})
+				scope.Set("ddd", &symbol.String{Name: &ast.Identifier{Name: "asdf"}})
 				return scope
 			},
 			&mockTokenBuffer{
@@ -2177,7 +2177,7 @@ func TestParseAssignStatement(t *testing.T) {
 		}
 
 		if err == nil && exp.Value.String() != tt.expectedVal {
-			t.Errorf("tests[%d] - Value is not %s but got %s",
+			t.Errorf("tests[%d] - Name is not %s but got %s",
 				i, tt.expectedVal, exp.Value.String())
 		}
 
@@ -3544,11 +3544,11 @@ func TestParseExpressionStatement(t *testing.T) {
 func TestEnterLeaveScope(t *testing.T) {
 	// scope is global variable which defined in parser.go
 	scope = symbol.NewScope()
-	scope.Set("foo", &symbol.String{Name: &ast.Identifier{Value: "foo"}})
+	scope.Set("foo", &symbol.String{Name: &ast.Identifier{Name: "foo"}})
 
 	enterScope()
 
-	scope.Set("bar", &symbol.String{Name: &ast.Identifier{Value: "bar"}})
+	scope.Set("bar", &symbol.String{Name: &ast.Identifier{Name: "bar"}})
 
 	if scope.Get("foo") == nil {
 		t.Errorf("scope should have foo symbol, because we're in the inner scope")
@@ -3556,7 +3556,7 @@ func TestEnterLeaveScope(t *testing.T) {
 
 	leaveScope()
 
-	scope.Set("baz", &symbol.String{Name: &ast.Identifier{Value: "baz"}})
+	scope.Set("baz", &symbol.String{Name: &ast.Identifier{Name: "baz"}})
 
 	if scope.Get("bar") != nil {
 		t.Errorf("scope should NOT have \"bar\" symbol, because we're in the outer scope")
@@ -3581,7 +3581,7 @@ func TestUpdateScopeSymbol(t *testing.T) {
 		{
 			setupScopeFn: func() *symbol.Scope {
 				scope := symbol.NewScope()
-				scope.Set("a", &symbol.Integer{Name: &ast.Identifier{Value: "1"}})
+				scope.Set("a", &symbol.Integer{Name: &ast.Identifier{Name: "1"}})
 				return scope
 			},
 			ident:       Token{Type: Ident, Val: "a"},

--- a/parse/parser_test.go
+++ b/parse/parser_test.go
@@ -271,7 +271,7 @@ func TestParse(t *testing.T) {
 
 func testFunctionLiteral(t *testing.T, fn *ast.FunctionLiteral, tt parserTestCase) {
 	t.Helper()
-	switch fn.Name.Value {
+	switch fn.Name.Name {
 	case "testReturnStatement":
 		testReturnStatementFunc(t, fn, tt)
 	case "testAssignStatement":
@@ -519,7 +519,7 @@ func testFnParameters(t *testing.T, p *ast.ParameterLiteral, ds ast.DataStructur
 		t.Errorf("wrong parameter type expected=%s, got=%s",
 			p.Type.String(), ds.String())
 	}
-	if p.Identifier.Value != id {
+	if p.Identifier.Name != id {
 		t.Errorf("wrong parameter identifier expected=%T, got=%T",
 			p.Type, ds)
 	}
@@ -530,9 +530,9 @@ func testAssignStatement(t *testing.T, stmt *ast.AssignStatement, ds ast.DataStr
 		t.Errorf("wrong assign statement type expected=%T, got=%T",
 			ds, stmt.Type)
 	}
-	if stmt.Variable.Value != ident {
+	if stmt.Variable.Name != ident {
 		t.Errorf("wrong assign statement variable expected=%s, got=%s",
-			ident, stmt.Variable.Value)
+			ident, stmt.Variable.Name)
 	}
 	if stmt.Value.String() != value {
 		t.Errorf("wrong assign statement value expected=%s, got=%s",

--- a/symbol/scope_test.go
+++ b/symbol/scope_test.go
@@ -55,35 +55,35 @@ func TestScopeGetter(t *testing.T) {
 		{
 			Scope{
 				map[string]Symbol{
-					"a": &Integer{&ast.Identifier{Value: "a"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
 				},
 				nil,
 			},
 			"a",
-			&Integer{&ast.Identifier{Value: "a"}},
+			&Integer{&ast.Identifier{Name: "a"}},
 		},
 		{
 			Scope{
 				map[string]Symbol{
-					"a": &Integer{&ast.Identifier{Value: "a"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
 				},
 				&Scope{
 					map[string]Symbol{
-						"c": &String{&ast.Identifier{Value: "c"}},
+						"c": &String{&ast.Identifier{Name: "c"}},
 					},
 					nil,
 				},
 			},
 			"c",
-			&String{&ast.Identifier{Value: "c"}},
+			&String{&ast.Identifier{Name: "c"}},
 		},
 		{
 			Scope{
 				map[string]Symbol{
-					"a": &Integer{&ast.Identifier{Value: "a"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
 				},
 				nil,
 			},
@@ -120,7 +120,7 @@ func TestScopeSetter(t *testing.T) {
 				&Scope{},
 			},
 			"testInt",
-			&Integer{&ast.Identifier{Value: "testInt"}},
+			&Integer{&ast.Identifier{Name: "testInt"}},
 		},
 		{
 			&Scope{
@@ -128,7 +128,7 @@ func TestScopeSetter(t *testing.T) {
 				&Scope{},
 			},
 			"testBool",
-			&Boolean{&ast.Identifier{Value: "testBool"}},
+			&Boolean{&ast.Identifier{Name: "testBool"}},
 		},
 		{
 			&Scope{
@@ -136,7 +136,7 @@ func TestScopeSetter(t *testing.T) {
 				&Scope{},
 			},
 			"testString",
-			&String{&ast.Identifier{Value: "testString"}},
+			&String{&ast.Identifier{Name: "testString"}},
 		},
 	}
 
@@ -163,8 +163,8 @@ func TestScopeString(t *testing.T) {
 		{
 			Scope{
 				map[string]Symbol{
-					"a": &Integer{&ast.Identifier{Value: "a"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
 				},
 				nil,
 			},
@@ -173,12 +173,12 @@ func TestScopeString(t *testing.T) {
 		{
 			Scope{
 				map[string]Symbol{
-					"a": &Integer{&ast.Identifier{Value: "a"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
 				},
 				&Scope{
 					map[string]Symbol{
-						"c": &String{&ast.Identifier{Value: "c"}},
+						"c": &String{&ast.Identifier{Name: "c"}},
 					},
 					nil,
 				},
@@ -188,13 +188,13 @@ func TestScopeString(t *testing.T) {
 		{
 			Scope{
 				map[string]Symbol{
-					"c": &Integer{&ast.Identifier{Value: "c"}},
-					"b": &Integer{&ast.Identifier{Value: "b"}},
-					"a": &Integer{&ast.Identifier{Value: "a"}},
+					"c": &Integer{&ast.Identifier{Name: "c"}},
+					"b": &Integer{&ast.Identifier{Name: "b"}},
+					"a": &Integer{&ast.Identifier{Name: "a"}},
 				},
 				&Scope{
 					map[string]Symbol{
-						"d": &String{&ast.Identifier{Value: "d"}},
+						"d": &String{&ast.Identifier{Name: "d"}},
 					},
 					nil,
 				},

--- a/symbol/symbol_test.go
+++ b/symbol/symbol_test.go
@@ -28,9 +28,9 @@ func TestInteger(t *testing.T) {
 		expectedStr    string
 		expectedSymbol SymbolType
 	}{
-		{&Integer{&ast.Identifier{Value: "testName"}}, "testName", IntegerSymbol},
-		{&Integer{&ast.Identifier{Value: "a"}}, "a", IntegerSymbol},
-		{&Integer{&ast.Identifier{Value: "b"}}, "b", IntegerSymbol},
+		{&Integer{&ast.Identifier{Name: "testName"}}, "testName", IntegerSymbol},
+		{&Integer{&ast.Identifier{Name: "a"}}, "a", IntegerSymbol},
+		{&Integer{&ast.Identifier{Name: "b"}}, "b", IntegerSymbol},
 	}
 
 	for i, test := range tests {
@@ -57,9 +57,9 @@ func TestString(t *testing.T) {
 		expectedStr    string
 		expectedSymbol SymbolType
 	}{
-		{&String{&ast.Identifier{Value: "testName"}}, "testName", StringSymbol},
-		{&String{&ast.Identifier{Value: "a"}}, "a", StringSymbol},
-		{&String{&ast.Identifier{Value: "b"}}, "b", StringSymbol},
+		{&String{&ast.Identifier{Name: "testName"}}, "testName", StringSymbol},
+		{&String{&ast.Identifier{Name: "a"}}, "a", StringSymbol},
+		{&String{&ast.Identifier{Name: "b"}}, "b", StringSymbol},
 	}
 
 	for i, test := range tests {
@@ -86,8 +86,8 @@ func TestBoolean(t *testing.T) {
 		expectedStr string
 		expectedObj SymbolType
 	}{
-		{&Boolean{&ast.Identifier{Value: "testName"}}, "testName", BooleanSymbol},
-		{&Boolean{&ast.Identifier{Value: "a"}}, "a", BooleanSymbol},
+		{&Boolean{&ast.Identifier{Name: "testName"}}, "testName", BooleanSymbol},
+		{&Boolean{&ast.Identifier{Name: "a"}}, "a", BooleanSymbol},
 	}
 
 	for i, test := range tests {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -73,7 +73,7 @@ func (cf CallFunc) function() []byte {
 // Example)
 // Pointer : 4bytes
 // Size : 4bytes
-// Value : dynamic
+// Name : dynamic
 // arguments(n) : if the number of arguments is 4, range of n is 0~3
 // cf.Args[n:n+4] : Pointer which point to value's size
 // after we know size, next to size is value.


### PR DESCRIPTION
resolved: #291 

details:

change from 

```go
// Represent identifier
type Identifier struct {
	Value string
}
```

to

```go
// Represent identifier
type Identifier struct {
	Name string
}
```
for having clear meaning