### PR TITLE
Feature/function jumper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/DE-labtory/koa
 require (
 	github.com/ethereum/go-ethereum v1.8.21
 	github.com/fatih/color v1.7.0
+	github.com/google/go-cmp v0.2.0
 	github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/mattn/go-colorable v0.0.9 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/pkg/errors v0.8.1
+	github.com/pkg/errors v0.8.1 // indirect
 	github.com/urfave/cli v1.20.0
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc
 	golang.org/x/sys v0.0.0-20190108104531-7fbe1cd0fcc2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/ethereum/go-ethereum v1.8.21 h1:ofzsxFj+zKhj1k3uVa8/MJCCptqKEh/6DXq4L
 github.com/ethereum/go-ethereum v1.8.21/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
+github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d h1:cVtBfNW5XTHiKQe7jDaDBSh/EVM4XLPutLAGboIXuM0=
 github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2viExyCEfeWGU259JnaQ34Inuec4R38JCyBx2edgD0=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/translate/bytecode.go
+++ b/translate/bytecode.go
@@ -28,8 +28,15 @@ type Bytecode struct {
 	AsmCode []string
 }
 
+func NewBytecode() *Bytecode {
+	return &Bytecode{
+		RawByte: make([]byte, 0),
+		AsmCode: make([]string, 0),
+	}
+}
+
 // Emerge() translates instruction to bytecode
-// An operand of operands should be 4 bytes.
+// An operand of operands should be 8 bytes.
 func (b *Bytecode) Emerge(operator opcode.Type, operands ...[]byte) int {
 	// Translate operator to byte
 	b.RawByte = append(b.RawByte, byte(operator))
@@ -52,4 +59,16 @@ func (b *Bytecode) Emerge(operator opcode.Type, operands ...[]byte) int {
 
 	// Returns next bytecode position
 	return len(b.AsmCode)
+}
+
+// Append() combines two bytecodes.
+// The bytecode of parameter will be appended to the end.
+func (b *Bytecode) Append(bytecode *Bytecode) {
+	for _, aByte := range bytecode.RawByte {
+		b.RawByte = append(b.RawByte, aByte)
+	}
+
+	for _, anAsm := range bytecode.AsmCode {
+		b.AsmCode = append(b.AsmCode, anAsm)
+	}
 }

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -26,6 +26,13 @@ import (
 	"github.com/DE-labtory/koa/opcode"
 )
 
+type FuncMap map[string]int
+
+func (m FuncMap) Declare(f ast.FunctionLiteral, b Bytecode) {
+	funcSel := abi.Selector(f.Signature())
+	m[string(funcSel)] = len(b.RawByte)
+}
+
 // TODO: implement me w/ test cases :-)
 // CompileContract() compiles a smart contract.
 // returns bytecode and error.
@@ -37,7 +44,11 @@ func CompileContract(c ast.Contract) (Bytecode, error) {
 
 	memTracer := NewMemEntryTable()
 
+	funcMap := FuncMap{}
+
 	for _, f := range c.Functions {
+		funcMap.Declare(*f, *bytecode)
+
 		if err := compileFunction(*f, bytecode, memTracer); err != nil {
 			return *bytecode, err
 		}
@@ -118,9 +129,6 @@ func compileStatement(s ast.Statement, bytecode *Bytecode, tracer MemTracer) err
 
 	case *ast.ExpressionStatement:
 		return compileExpressionStatement(statement, bytecode)
-
-	case *ast.FunctionLiteral:
-		return compileFunctionLiteral(statement, bytecode)
 
 	default:
 		return nil
@@ -218,9 +226,6 @@ func compileExpression(e ast.Expression, bytecode *Bytecode) error {
 
 	case *ast.Identifier:
 		return compileIdentifier(expr, bytecode)
-
-	case *ast.ParameterLiteral:
-		return compileParameterLiteral(expr, bytecode)
 
 	default:
 		return errors.New("compileExpression() error")

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -80,14 +80,40 @@ func expectFuncJumper(c ast.Contract, funcMap FuncMap) error {
 	return nil
 }
 
-// TODO: implement me w/ test cases :-)
-// Generates a bytecode of function jumper.
+// Generates the function jumper in front of the bytecode.
 func generateFuncJumper(c ast.Contract, bytecode *Bytecode, funcMap FuncMap) error {
+	funcJpr := NewBytecode()
+
+	// Loads the function selector of call function.
+	funcJpr.Emerge(opcode.LoadFunc)
+
+	// Compares and finds the corresponding function selector.
+	for _, f := range c.Functions {
+		if err := compileFunctionLiteral(f, funcJpr, funcMap); err != nil {
+			return err
+		}
+	}
+
+	// No match to any function selector, Revert!
+	funcJpr.Emerge(opcode.JumpDst)
+	operand, err := encoding.EncodeOperand(0)
+	if err != nil {
+		return err
+	}
+	funcJpr.Emerge(opcode.Push, operand)
+	funcJpr.Emerge(opcode.DUP)
+	funcJpr.Emerge(opcode.Returning)
+
+	// Add function jumper to bytecode
+	// [bytecode] => [function jumper][bytecode]
+	funcJpr.Append(bytecode)
+	bytecode = funcJpr
+
 	return nil
 }
 
 // TODO: implement me w/ test cases :-)
-func compileFunctionLiteral(s *ast.FunctionLiteral, bytecode *Bytecode) error {
+func compileFunctionLiteral(s *ast.FunctionLiteral, bytecode *Bytecode, funcMap FuncMap) error {
 	return nil
 }
 

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -54,11 +54,46 @@ func CompileContract(c ast.Contract) (Bytecode, error) {
 		}
 	}
 
-	if err := generateFuncJumper(bytecode); err != nil {
+	if err := expectFuncJumper(c, funcMap); err != nil {
+		return *bytecode, err
+	}
+
+	if err := generateFuncJumper(c, bytecode, funcMap); err != nil {
 		return *bytecode, err
 	}
 
 	return *bytecode, nil
+}
+
+// Expects a size of the function jumper and updates the function map.
+func expectFuncJumper(c ast.Contract, funcMap FuncMap) error {
+	expectedJpr := NewBytecode()
+	if err := generateFuncJumper(c, expectedJpr, funcMap); err != nil {
+		return err
+	}
+
+	// Updates the function map with a size of function jumper.
+	for funcSel, pc := range funcMap {
+		funcMap[funcSel] = pc + len(expectedJpr.RawByte)
+	}
+
+	return nil
+}
+
+// TODO: implement me w/ test cases :-)
+// Generates a bytecode of function jumper.
+func generateFuncJumper(c ast.Contract, bytecode *Bytecode, funcMap FuncMap) error {
+	return nil
+}
+
+// TODO: implement me w/ test cases :-)
+func compileFunctionLiteral(s *ast.FunctionLiteral, bytecode *Bytecode) error {
+	return nil
+}
+
+// TODO: implement me w/ test cases :-)
+func compileParameterLiteral(e *ast.ParameterLiteral, bytecode *Bytecode) error {
+	return nil
 }
 
 func ExtractAbi(c ast.Contract) (*abi.ABI, error) {
@@ -70,12 +105,6 @@ func ExtractAbi(c ast.Contract) (*abi.ABI, error) {
 	return &abi.ABI{
 		Methods: abiMethods,
 	}, nil
-}
-
-// TODO: implement me w/ test cases :-)
-// Generates a bytecode of function jumper.
-func generateFuncJumper(bytecode *Bytecode) error {
-	return nil
 }
 
 // Generates the ABI of functions in contract.
@@ -194,11 +223,6 @@ func compileBlockStatement(s *ast.BlockStatement, bytecode *Bytecode, tracer Mem
 
 func compileExpressionStatement(s *ast.ExpressionStatement, bytecode *Bytecode) error {
 	return compileExpression(s.Expr, bytecode)
-}
-
-// TODO: implement me w/ test cases :-)
-func compileFunctionLiteral(s *ast.FunctionLiteral, bytecode *Bytecode) error {
-	return nil
 }
 
 // TODO: implement me w/ test cases :-)
@@ -326,10 +350,5 @@ func compileBooleanLiteral(e *ast.BooleanLiteral, bytecode *Bytecode) error {
 
 // TODO: implement me w/ test cases :-)
 func compileIdentifier(e *ast.Identifier, bytecode *Bytecode) error {
-	return nil
-}
-
-// TODO: implement me w/ test cases :-)
-func compileParameterLiteral(e *ast.ParameterLiteral, bytecode *Bytecode) error {
 	return nil
 }

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -114,6 +114,24 @@ func generateFuncJumper(c ast.Contract, bytecode *Bytecode, funcMap FuncMap) err
 
 // TODO: implement me w/ test cases :-)
 func compileFunctionLiteral(s *ast.FunctionLiteral, bytecode *Bytecode, funcMap FuncMap) error {
+	// Duplicates the function selector to find.
+	bytecode.Emerge(opcode.DUP)
+	// Pushes the function selector of this function literal.
+	selector := string(abi.Selector(s.Signature()))
+	funcSel, err := encoding.EncodeOperand(selector)
+	if err != nil {
+		return err
+	}
+	bytecode.Emerge(opcode.Push, funcSel)
+	bytecode.Emerge(opcode.EQ)
+	// If the result is equal, Pushed the pc to jump.
+	pc, err := encoding.EncodeOperand(funcMap[selector])
+	if err != nil {
+		return err
+	}
+	bytecode.Emerge(opcode.Push, pc)
+	bytecode.Emerge(opcode.Jumpi)
+
 	return nil
 }
 

--- a/translate/compiler_internal_test.go
+++ b/translate/compiler_internal_test.go
@@ -38,7 +38,15 @@ func TestGenerateFuncJumper(t *testing.T) {
 
 }
 
-func TestCompileFunctionLiteral(t *testing.T) {
+func TestRelocateFuncJumper(t *testing.T) {
+
+}
+
+func TestCompileRevert(t *testing.T) {
+
+}
+
+func TestCompileFuncSelector(t *testing.T) {
 
 }
 

--- a/translate/compiler_internal_test.go
+++ b/translate/compiler_internal_test.go
@@ -30,8 +30,20 @@ type expressionCompileTestCase struct {
 	expected   Bytecode
 }
 
-// TODO: implement test cases :-)
+func TestExpectFuncJumper(t *testing.T) {
+
+}
+
 func TestGenerateFuncJumper(t *testing.T) {
+
+}
+
+func TestCompileFunctionLiteral(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestCompileParameterLiteral(t *testing.T) {
 
 }
 
@@ -240,11 +252,6 @@ func TestCompileExpressionStatement(t *testing.T) {
 			}
 		}
 	}
-
-}
-
-// TODO: implement test cases :-)
-func TestCompileFunctionLiteral(t *testing.T) {
 
 }
 
@@ -922,11 +929,6 @@ func TestCompileBooleanLiteral(t *testing.T) {
 
 // TODO: implement test cases :-)
 func TestCompileIdentifier(t *testing.T) {
-
-}
-
-// TODO: implement test cases :-)
-func TestCompileParameterLiteral(t *testing.T) {
 
 }
 

--- a/translate/compiler_test.go
+++ b/translate/compiler_test.go
@@ -35,14 +35,16 @@ func TestFuncMap_Declare(t *testing.T) {
 			funcLiteral: makeFuncLiteral("foo", ast.VoidType),
 			b: translate.Bytecode{
 				RawByte: []byte{01, 02, 03, 04},
+				AsmCode: []string{"01020304"},
 			},
-			pc:  4,
+			pc:  1,
 			len: 1,
 		},
 		{
 			funcLiteral: makeFuncLiteral("bar", ast.IntType),
 			b: translate.Bytecode{
 				RawByte: []byte{05, 06},
+				AsmCode: []string{"05", "06"},
 			},
 			pc:  2,
 			len: 2,
@@ -51,6 +53,7 @@ func TestFuncMap_Declare(t *testing.T) {
 			funcLiteral: makeFuncLiteral("sam", ast.StringType),
 			b: translate.Bytecode{
 				RawByte: []byte{11, 12, 13, 14, 15, 16},
+				AsmCode: []string{"11", "12", "13", "14", "15", "16"},
 			},
 			pc:  6,
 			len: 3,
@@ -60,7 +63,7 @@ func TestFuncMap_Declare(t *testing.T) {
 	fMap := translate.FuncMap{}
 
 	for i, test := range tests {
-		fMap.Declare(test.funcLiteral, test.b)
+		fMap.Declare(test.funcLiteral.Signature(), test.b)
 
 		result := fMap[string(abi.Selector(test.funcLiteral.Signature()))]
 		if test.pc != result {

--- a/translate/compiler_test.go
+++ b/translate/compiler_test.go
@@ -16,9 +16,82 @@
 
 package translate_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/DE-labtory/koa/abi"
+	"github.com/DE-labtory/koa/ast"
+	"github.com/DE-labtory/koa/translate"
+)
+
+func TestFuncMap_Declare(t *testing.T) {
+	tests := []struct {
+		funcLiteral ast.FunctionLiteral
+		b           translate.Bytecode
+		pc          int
+		len         int
+	}{
+		{
+			funcLiteral: makeFuncLiteral("foo", ast.VoidType),
+			b: translate.Bytecode{
+				RawByte: []byte{01, 02, 03, 04},
+			},
+			pc:  4,
+			len: 1,
+		},
+		{
+			funcLiteral: makeFuncLiteral("bar", ast.IntType),
+			b: translate.Bytecode{
+				RawByte: []byte{05, 06},
+			},
+			pc:  2,
+			len: 2,
+		},
+		{
+			funcLiteral: makeFuncLiteral("sam", ast.StringType),
+			b: translate.Bytecode{
+				RawByte: []byte{11, 12, 13, 14, 15, 16},
+			},
+			pc:  6,
+			len: 3,
+		},
+	}
+
+	fMap := translate.FuncMap{}
+
+	for i, test := range tests {
+		fMap.Declare(test.funcLiteral, test.b)
+
+		result := fMap[string(abi.Selector(test.funcLiteral.Signature()))]
+		if test.pc != result {
+			t.Fatalf("test[%d] - Declare() pc result wrong. expected=%d, got=%d",
+				i, test.pc, result)
+		}
+
+		if test.len != len(fMap) {
+			t.Fatalf("test[%d] - Declare() FuncMap result wrong. expected=%d, got=%d", i, test.len, len(fMap))
+		}
+	}
+}
 
 // TODO: implement test cases :-)
 func TestCompileContract(t *testing.T) {
 
+}
+
+func makeFuncLiteral(funcName string, retType ast.DataStructure, params ...*ast.ParameterLiteral) ast.FunctionLiteral {
+	funcLiteral := ast.FunctionLiteral{
+		Name: &ast.Identifier{
+			Value: funcName,
+		},
+		Parameters: []*ast.ParameterLiteral{},
+		Body:       &ast.BlockStatement{},
+		ReturnType: retType,
+	}
+
+	for _, param := range params {
+		funcLiteral.Parameters = append(funcLiteral.Parameters, param)
+	}
+
+	return funcLiteral
 }

--- a/translate/tracer.go
+++ b/translate/tracer.go
@@ -48,7 +48,7 @@ type MemDefiner interface {
 // GetOffsetOfEntry() returns the offset of the memory entry corresponding the Id.
 // GetSizeOfEntry() returns the size of the memory entry corresponding the Id.
 type MemEntryGetter interface {
-	GetEntry(id string) (MemEntry, error)
+	Entry(id string) (MemEntry, error)
 }
 
 // MemEntry saves size and offset of the value which the variable has.
@@ -82,7 +82,7 @@ func (m *MemEntryTable) Define(id string) MemEntry {
 	return entry
 }
 
-func (m MemEntryTable) GetEntry(id string) (MemEntry, error) {
+func (m MemEntryTable) Entry(id string) (MemEntry, error) {
 	entry, ok := m.EntryMap[id]
 	if !ok {
 		return MemEntry{}, EntryError{

--- a/translate/tracer_test.go
+++ b/translate/tracer_test.go
@@ -105,14 +105,14 @@ func TestMemEntryTable_GetEntry(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		entry, err := mTable.GetEntry(test.id)
+		entry, err := mTable.Entry(test.id)
 
 		if err != nil && err.Error() != test.err.Error() {
-			t.Fatalf("test[%d] - GetEntry() error wrong. expected=%v, err=%v", i, test.err, err)
+			t.Fatalf("test[%d] - Entry() error wrong. expected=%v, err=%v", i, test.err, err)
 		}
 
 		if entry != test.expected {
-			t.Fatalf("test[%d] - GetEntry() result wrong. expected=%x, got=%x", i, test.expected, entry)
+			t.Fatalf("test[%d] - Entry() result wrong. expected=%x, got=%x", i, test.expected, entry)
 		}
 	}
 }


### PR DESCRIPTION
resolved: #279 

details:

1. Define `FuncMap` which has the location(program counter) of each function.
2. Implemented Function Jumper!

**Compile Flow**
1. compile each function.
2. expect function jumper size (because the size depends on the number of functions).
3. generate function jumper.
4. combine the function jumper and the byte code (which is compiled for function logic).

**Function Jumper Logic**
1. load call function selector (`LoadFunc`)
2. duplicate call function selector.
3. push the function selector of function being compiled.
4. compare call function selector with the selector being compiled.
5. push the location(program counter) to jump.
6. repeat 2~5 for each function.
7. add logic to revert (nothing corresponding to call function selector).

reference: https://blog.zeppelin.solutions/deconstructing-a-solidity-contract-part-iii-the-function-selector-6a9b6886ea49

*Test case not yet. Plz wait :)*

- [ ] Test case