### PR TITLE
bug: enter/leave scope when start parsing function literal

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -562,6 +562,8 @@ func parseStringLiteral(buf TokenBuffer) (ast.Expression, error) {
 // parseFunctionLiteral parse functional expression
 // first parse name, and parse parameter, body
 func parseFunctionLiteral(buf TokenBuffer) (*ast.FunctionLiteral, error) {
+	enterScope()
+
 	lit := &ast.FunctionLiteral{}
 	var err error
 
@@ -598,6 +600,7 @@ func parseFunctionLiteral(buf TokenBuffer) (*ast.FunctionLiteral, error) {
 	}
 
 	consumeSemi(buf)
+	leaveScope()
 
 	return lit, nil
 }

--- a/parse/parser_internal_test.go
+++ b/parse/parser_internal_test.go
@@ -164,6 +164,45 @@ func bar() void {
 				[]Token{
 					{Type: Contract, Val: "contract"},
 					{Type: Lbrace, Val: "{"},
+					{Type: Function, Val: "func"},
+					{Type: Ident, Val: "foo"},
+					{Type: Lparen, Val: "("},
+					{Type: Ident, Val: "a"},
+					{Type: IntType, Val: "int"},
+					{Type: Rparen, Val: ")"},
+					{Type: Lbrace, Val: "{"},
+					{Type: Rbrace, Val: "}"},
+					{Type: Semicolon, Val: "\n"},
+					{Type: Function, Val: "func"},
+					{Type: Ident, Val: "bar"},
+					{Type: Lparen, Val: "("},
+					{Type: Ident, Val: "a"},
+					{Type: IntType, Val: "int"},
+					{Type: Rparen, Val: ")"},
+					{Type: Lbrace, Val: "{"},
+					{Type: Rbrace, Val: "}"},
+					{Type: Semicolon, Val: "\n"},
+					{Type: Rbrace, Val: "}"},
+					{Type: Semicolon, Val: "\n"},
+					{Type: Eof},
+				},
+				0,
+			},
+			expected: `
+contract {
+func foo(Parameter : (Identifier: a, Type: int)) void {
+
+}
+func bar(Parameter : (Identifier: a, Type: int)) void {
+
+}
+}`,
+		},
+		{
+			buf: &mockTokenBuffer{
+				[]Token{
+					{Type: Contract, Val: "contract"},
+					{Type: Lbrace, Val: "{"},
 					{Type: IntType, Val: "int"},
 					{Type: Ident, Val: "a"},
 					{Type: Assign, Val: "="},


### PR DESCRIPTION
resolved: #309

details:

enter/leave scope when start parsing function literal, as a result we can now parsing like this situation:

```
contract {
    func foo(a int) {}
    func bar(a int) {} // now we can use `a` in the parameter
}
```

- [x] Test case