### PR TITLE
Feature/func jumper

### DIFF
--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -26,6 +26,14 @@ import (
 	"github.com/DE-labtory/koa/opcode"
 )
 
+type FuncMap map[string]int
+
+// Declare() saves the start point of function.
+func (m FuncMap) Declare(signature string, asm Asm) {
+	funcSig := abi.Selector(signature)
+	m[string(funcSig)] = len(asm.AsmCodes)
+}
+
 // TODO: implement me w/ test cases :-)
 // CompileContract() compiles a smart contract.
 // returns bytecode and error.
@@ -36,7 +44,10 @@ func CompileContract(c ast.Contract) (Asm, error) {
 
 	memTracer := NewMemEntryTable()
 
+	funcMap := FuncMap{}
 	for _, f := range c.Functions {
+		funcMap.Declare(f.Signature(), *asm)
+
 		if err := compileFunction(*f, asm, memTracer); err != nil {
 			return *asm, err
 		}

--- a/translate/compiler_internal_test.go
+++ b/translate/compiler_internal_test.go
@@ -17,9 +17,11 @@
 package translate
 
 import (
+	"bytes"
 	"errors"
 	"testing"
 
+	"github.com/DE-labtory/koa/abi"
 	"github.com/DE-labtory/koa/ast"
 	"github.com/DE-labtory/koa/opcode"
 )
@@ -37,8 +39,202 @@ type expressionCompileTestCase struct {
 	expectedErr error
 }
 
+func TestExpectFuncJmpr(t *testing.T) {
+	tests := []struct {
+		contract      ast.Contract
+		expectAsm     *Asm
+		expectFuncMap FuncMap
+		err           error
+	}{
+		{
+			contract: ast.Contract{
+				Functions: []*ast.FunctionLiteral{
+					{
+						Name: &ast.Identifier{
+							Value: "foo",
+						},
+					},
+				},
+			},
+			expectAsm: &Asm{
+				AsmCodes: []AsmCode{
+					// Push 0000000000000000
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						Value:   "0000000000000000",
+					},
+					// LoadFunc
+					{
+						RawByte: []byte{0x24},
+						Value:   "LoadFunc",
+					},
+					// DUP
+					{
+						RawByte: []byte{0x30},
+						Value:   "DUP",
+					},
+					// Push c5d2460100000000
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0xc5, 0xd2, 0x46, 0x01, 0x00, 0x00, 0x00, 0x001},
+						Value:   "c5d2460100000000",
+					},
+					// EQ
+					{
+						RawByte: []byte{0x14},
+						Value:   "EQ",
+					},
+					// Push 0000000000000000
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						Value:   "0000000000000000",
+					},
+					// Jumpi
+					{
+						RawByte: []byte{0x29},
+						Value:   "Jumpi",
+					},
+					// Returning
+					{
+						RawByte: []byte{0x26},
+						Value:   "Returning",
+					},
+				},
+			},
+			expectFuncMap: FuncMap{
+				string(abi.Selector("FuncJmpr")): 3,
+				string(abi.Selector("Revert")):   10,
+			},
+			err: nil,
+		},
+	}
+
+	for i, test := range tests {
+		asm := &Asm{
+			AsmCodes: []AsmCode{},
+		}
+		funcMap := FuncMap{}
+
+		err := expectFuncJmpr(test.contract, asm, funcMap)
+
+		if !compareAsm(*asm, *test.expectAsm) {
+			t.Fatalf("test[%d] - expectFuncJmpr() bytecode result wrong.\nexpected=%v,\ngot=%v", i, test.expectAsm, asm)
+		}
+
+		if !compareFuncMap(funcMap, test.expectFuncMap) {
+			t.Fatalf("test[%d] - expectFuncJmpr() FuncMap result wrong.\nexpected=%v,\ngot=%v", i, test.expectFuncMap, funcMap)
+		}
+
+		if err != nil && err != test.err {
+			t.Fatalf("test[%d] - expectFuncJmpr() error wrong.\nexpected=%v,\ngot=%v", i, test.err, err)
+		}
+	}
+}
+
+func TestCompileProgramEndPoint(t *testing.T) {
+	tests := []struct {
+		revertDst int
+		expect    Asm
+		err       error
+	}{
+		{
+			revertDst: 0,
+			expect: Asm{
+				AsmCodes: []AsmCode{
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00},
+						Value:   "0000000000000000",
+					},
+				},
+			},
+			err: nil,
+		},
+		{
+			revertDst: 1234,
+			expect: Asm{
+				AsmCodes: []AsmCode{
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0xd2},
+						Value:   "00000000000004d2",
+					},
+				},
+			},
+			err: nil,
+		},
+	}
+
+	for i, test := range tests {
+		asm := &Asm{
+			AsmCodes: make([]AsmCode, 0),
+		}
+
+		err := compileProgramEndPoint(asm, test.revertDst)
+
+		if !compareAsm(*asm, test.expect) {
+			t.Fatalf("test[%d] - compileProgramEndPoint() result wrong. expected=%v, got=%v", i, test.expect, asm)
+		}
+
+		if err != nil && err != test.err {
+			t.Fatalf("test[%d] - compileProgramEndPoint() error wrong. expected=%v, got=%v", i, test.err, err)
+		}
+	}
+}
+
+func TestCompileRevert(t *testing.T) {
+	tests := []struct {
+		expect Asm
+	}{
+		{
+			expect: Asm{
+				AsmCodes: []AsmCode{
+					{
+						RawByte: []byte{0x26},
+						Value:   "Returning",
+					},
+				},
+			},
+		},
+	}
+
+	asm := &Asm{
+		AsmCodes: make([]AsmCode, 0),
+	}
+
+	for i, test := range tests {
+		compileRevert(asm)
+
+		if !compareAsm(*asm, test.expect) {
+			t.Fatalf("test[%d] - compileRevert() result wrong. expected=%v, got=%v", i, test.expect, asm)
+		}
+	}
+}
+
 // TODO: implement test cases :-)
-func TestGenerateFuncJumper(t *testing.T) {
+func TestGenerateFuncJmpr(t *testing.T) {
+
+}
+
+// TODO: implement test cases :-)
+func TestCompileFuncSel(t *testing.T) {
 
 }
 
@@ -1575,4 +1771,32 @@ func makeTempStatements() []ast.Statement {
 	})
 
 	return statements
+}
+
+func compareAsm(asm1 Asm, asm2 Asm) bool {
+	for i, asmCode := range asm1.AsmCodes {
+		if !bytes.Equal(asmCode.RawByte, asm2.AsmCodes[i].RawByte) {
+			return false
+		}
+
+		if asmCode.Value != asm2.AsmCodes[i].Value {
+			return false
+		}
+	}
+
+	return true
+}
+
+func compareFuncMap(funcMap1 FuncMap, funcMap2 FuncMap) bool {
+	if len(funcMap1) != len(funcMap2) {
+		return false
+	}
+
+	for funcSel, item := range funcMap1 {
+		if item != funcMap2[funcSel] {
+			return false
+		}
+	}
+
+	return true
 }

--- a/translate/compiler_test.go
+++ b/translate/compiler_test.go
@@ -16,9 +16,85 @@
 
 package translate_test
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/DE-labtory/koa/abi"
+	"github.com/DE-labtory/koa/translate"
+)
 
 // TODO: implement test cases :-)
 func TestCompileContract(t *testing.T) {
 
+}
+
+func TestFuncMap_Declare(t *testing.T) {
+	tests := []struct {
+		signature string
+		asm       translate.Asm
+		expectPC  int
+		expectLen int
+	}{
+		{
+			signature: "foo()",
+			asm: translate.Asm{
+				AsmCodes: []translate.AsmCode{
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+						Value:   "0001020304050607",
+					},
+				},
+			},
+			expectPC:  2,
+			expectLen: 1,
+		},
+		{
+			signature: "bar()",
+			asm: translate.Asm{
+				AsmCodes: []translate.AsmCode{
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+						Value:   "0001020304050607",
+					},
+					{
+						RawByte: []byte{0x21},
+						Value:   "Push",
+					},
+					{
+						RawByte: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07},
+						Value:   "0001020304050607",
+					},
+					{
+						RawByte: []byte{0x01},
+						Value:   "Add",
+					},
+				},
+			},
+			expectPC:  5,
+			expectLen: 2,
+		},
+	}
+
+	funcMap := translate.FuncMap{}
+	for i, test := range tests {
+		funcMap.Declare(test.signature, test.asm)
+
+		result := funcMap[string(abi.Selector(test.signature))]
+
+		if test.expectPC != result {
+			t.Fatalf("test[%d] - Declare() pc result wrong. expected=%d, got=%d", i, test.expectPC, result)
+		}
+
+		if test.expectLen != len(funcMap) {
+			t.Fatalf("test[%d] - Declare() FuncMap result wrong. expected=%d, got=%d", i, test.expectLen, len(funcMap))
+		}
+	}
 }


### PR DESCRIPTION
resolved: #279

details:

1. Define `FuncMap` which has the location(program counter) of each function.
2. Implemented Function Jumper!

**Compile Flow**

1. expect function jumper to calculate function jumper size. (`expectFuncJmpr()`)
2. compile each function updating `FuncMap`. (`compileFunction()`)
3. generate function jumper with updated `FuncMap`. (`generateFuncJmpr()`)

**Function Jumper Logic**

1. push the location of REVERT. this location is used to exit the program.
2. load function selector of call function. (`LoadFunc`)
3. duplicate call function selector.
4. push the function selector of function being compiled.
5. compare call function selector with the selector being compiled.
6. push the location(program counter) to jump.
7. repeat 3~6 for each function.
8. add logic to revert (nothing corresponding to call function selector or program finished).

**Reference** 
1. https://blog.zeppelin.solutions/deconstructing-a-solidity-contract-part-iii-the-function-selector-6a9b6886ea49
2. #305 

* [x]  Test case