### PR TITLE
Feature/vm/execute

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -233,12 +233,12 @@ func (f *FunctionLiteral) String() string {
 
 func (f *FunctionLiteral) Signature() string {
 
-	params := []string{}
+	paramTypes := []string{}
 	for _, p := range f.Parameters {
-		params = append(params, p.String())
+		paramTypes = append(paramTypes, p.Type.String())
 	}
 
-	return fmt.Sprintf("%s(%s)", f.Name.String(), strings.Join(params, ","))
+	return fmt.Sprintf("%s(%s)", f.Name.String(), strings.Join(paramTypes, ","))
 }
 
 // Represent block statement

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -238,7 +238,7 @@ func (f *FunctionLiteral) Signature() string {
 		params = append(params, p.String())
 	}
 
-	return fmt.Sprintf("func %s(%s)", f.Name.String(), strings.Join(params, ", "))
+	return fmt.Sprintf("%s(%s)", f.Name.String(), strings.Join(params, ","))
 }
 
 // Represent block statement

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -299,7 +299,7 @@ func TestFunctionLiteral_Signature(t *testing.T) {
 			input: FunctionLiteral{
 				Name: &Identifier{Name: "foo"},
 			},
-			expected: "func foo()",
+			expected: "foo()",
 		},
 		{
 			input: FunctionLiteral{
@@ -311,7 +311,7 @@ func TestFunctionLiteral_Signature(t *testing.T) {
 					},
 				},
 			},
-			expected: "func foo(Parameter : (Identifier: a, Type: int))",
+			expected: "foo(int)",
 		},
 		{
 			input: FunctionLiteral{
@@ -327,7 +327,7 @@ func TestFunctionLiteral_Signature(t *testing.T) {
 					},
 				},
 			},
-			expected: "func foo(Parameter : (Identifier: a, Type: int), Parameter : (Identifier: b, Type: string))",
+			expected: "foo(int,string)",
 		},
 	}
 

--- a/koa.go
+++ b/koa.go
@@ -1,6 +1,8 @@
 package koa
 
 import (
+	"encoding/binary"
+
 	"github.com/DE-labtory/koa/abi"
 	"github.com/DE-labtory/koa/parse"
 	"github.com/DE-labtory/koa/translate"
@@ -29,11 +31,24 @@ func Compile(input string) (translate.Asm, abi.ABI, error) {
 	return asm, *a, nil
 }
 
-func Execute(rawByteCode []byte, callFunc *vm.CallFunc) (int64, error) {
-	_, err := vm.Execute(rawByteCode, vm.NewMemory(), callFunc)
-	if err != nil {
-		return 0, err
+func Execute(rawByteCode []byte, function []byte, args []byte) ([]byte, error) {
+	callFunc := &vm.CallFunc{
+		Func: function,
+		Args: args,
 	}
 
-	return 0, nil
+	stack, err := vm.Execute(rawByteCode, vm.NewMemory(), callFunc)
+	if err != nil {
+		return nil, err
+	}
+
+	output := Bytes(int64(stack.Pop()))
+
+	return output, nil
+}
+
+func Bytes(item int64) []byte {
+	byteSlice := make([]byte, 8)
+	binary.BigEndian.PutUint64(byteSlice, uint64(item))
+	return byteSlice
 }

--- a/koa_test.go
+++ b/koa_test.go
@@ -370,3 +370,87 @@ func TestCompile(t *testing.T) {
 		}
 	}
 }
+
+func TestExecute(t *testing.T) {
+	///*
+	//contract {
+	//	func addVariable() int {
+	//		int a = 5
+	//		int b = 10
+	//		return a + b
+	//	}
+	//
+	//	func addNative() int {
+	//		return 5 + 10
+	//	}
+	//
+	//	func addArgs(a int, b int) int {
+	//		return a + b
+	//	}
+	//}
+	// */
+	//firstContractRawBytecode, err := hex.DecodeString("21000000000000001b24302100000000652f6077141521000000000000001c29302100000000a82ed9f7141521000000000000003629302100000000bdbaf70e141521000000000000003c29322100000000000000052100000000000000082100000000000000002321000000000000000a210000000000000008210000000000000008232100000000000000082100000000000000002221000000000000000821000000000000000822012621000000000000000521000000000000000a01262100000000000000002521000000000000000821000000000000001023210000000000000001252100000000000000082100000000000000182321000000000000000821000000000000001022210000000000000008210000000000000018220126")
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	//
+	///*
+	//contract {
+	//	func hello() string{
+	//		return "hello!"
+	//	}
+	//}
+	// */
+	//secondContractRawBytecode, err := hex.DecodeString("21000000000000000b2430210000000019ff1d21141521000000000000000c2932212268656c6c6f212226")
+	//if err != nil {
+	//	t.Error(err)
+	//}
+	//
+	//firstArgs1, err := abi.Encode()
+	//firstArgs2, err := abi.Encode()
+	//firstArgs3, err := abi.Encode(5, 10)
+	//second1, err := abi.Encode()
+	//
+	//tests := []struct {
+	//	RawBytecode []byte
+	//	Func []byte
+	//	Args []byte
+	//	output []byte
+	//}{
+	//	{
+	//		RawBytecode: firstContractRawBytecode,
+	//		Func: abi.Selector("addVariable()"),
+	//		Args: firstArgs1,
+	//		output: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f},
+	//	},
+	//	{
+	//		RawBytecode: firstContractRawBytecode,
+	//		Func: abi.Selector("addNative()"),
+	//		Args: firstArgs2,
+	//		output: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f},
+	//	},
+	//	{
+	//		RawBytecode: firstContractRawBytecode,
+	//		Func: abi.Selector("addArgs(int,int)"),
+	//		Args: firstArgs3,
+	//		output: []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0f},
+	//	},
+	//	{
+	//		RawBytecode: secondContractRawBytecode,
+	//		Func: abi.Selector("hello()"),
+	//		Args: second1,
+	//		output: []byte{0x22, 0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x21, 0x22},
+	//	},
+	//}
+	//
+	//for _, test := range tests {
+	//	output, err := Execute(test.RawBytecode, test.Func, test.Args)
+	//	if err != nil {
+	//		t.Error(err)
+	//	}
+	//
+	//	if !bytes.Equal(test.output, output) {
+	//		t.Errorf("Invalid output - expected=%x, got=%x ", test.output, output)
+	//	}
+	//}
+}

--- a/test/add.koa
+++ b/test/add.koa
@@ -1,0 +1,15 @@
+contract {
+	func addVariable() int {
+		int a = 5
+		int b = 10
+		return a + b
+	}
+
+	func addNative() int {
+		return 5 + 10
+	}
+
+	func addArgs(a int, b int) int {
+		return a + b
+	}
+}

--- a/translate/compiler.go
+++ b/translate/compiler.go
@@ -82,14 +82,14 @@ func createFuncJmprPlaceholder(c ast.Contract, asm *Asm, funcMap FuncMap) error 
 	// Adds the logic to compare and find the corresponding function selector with the unmeaningful value.
 	funcMap.Declare("FuncJmpr", *asm)
 	for range c.Functions {
-		if err := compileFuncSel(asm, string(abi.Selector("")), 0); err != nil {
+		if err := compileFuncSel(asm, abi.Selector(""), 0); err != nil {
 			return err
 		}
 	}
 
 	// No match to any function selector, Revert!
 	funcMap.Declare("Revert", *asm)
-	compileRevert(asm)
+	compileExit(asm)
 
 	return nil
 }
@@ -105,10 +105,10 @@ func compileProgramEndPoint(asm *Asm, revertDst int) error {
 	return nil
 }
 
-// compileRevert compiles exiting the program.
+// compileExit compiles exiting the program.
 // If jumps to here, exit the program.
-func compileRevert(asm *Asm) {
-	asm.Emerge(opcode.Returning)
+func compileExit(asm *Asm) {
+	asm.Emerge(opcode.Exit)
 }
 
 // Generates a bytecode of function jumper.
@@ -128,8 +128,8 @@ func compileFuncJmpr(c ast.Contract, asm *Asm, funcMap FuncMap) error {
 
 	// Adds the logic to compare and find the corresponding function selector.
 	for _, f := range c.Functions {
-		selector := string(abi.Selector(f.Signature()))
-		funcDst := funcMap[selector]
+		selector := abi.Selector(f.Signature())
+		funcDst := funcMap[string(selector)]
 
 		if err := compileFuncSel(funcJmpr, selector, funcDst); err != nil {
 			return err
@@ -137,7 +137,7 @@ func compileFuncJmpr(c ast.Contract, asm *Asm, funcMap FuncMap) error {
 	}
 
 	// No match to any function selector, Revert!
-	compileRevert(funcJmpr)
+	compileExit(funcJmpr)
 
 	// Replace expected function jumper with new function jumper.
 	if err := fillFuncJmpr(asm, *funcJmpr); err != nil {
@@ -161,7 +161,7 @@ func fillFuncJmpr(asm *Asm, funcJmpr Asm) error {
 }
 
 // Compiles function jumper logic to find a function with its function selector
-func compileFuncSel(asm *Asm, funcSel string, funcDst int) error {
+func compileFuncSel(asm *Asm, funcSel []byte, funcDst int) error {
 	// Duplicates the function selector to find.
 	asm.Emerge(opcode.DUP)
 	// Pushes the function selector of this function literal.

--- a/translate/compiler_internal_test.go
+++ b/translate/compiler_internal_test.go
@@ -89,8 +89,8 @@ func TestCreateFuncJmprPlaceholder(t *testing.T) {
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0xc5, 0xd2, 0x46, 0x01, 0x00, 0x00, 0x00, 0x00},
-						Value:   "c5d2460100000000",
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0xc5, 0xd2, 0x46, 0x01},
+						Value:   "00000000c5d24601",
 					},
 					// EQ
 					{
@@ -116,10 +116,10 @@ func TestCreateFuncJmprPlaceholder(t *testing.T) {
 						RawByte: []byte{0x29},
 						Value:   "Jumpi",
 					},
-					// Returning
+					// Exit
 					{
-						RawByte: []byte{0x26},
-						Value:   "Returning",
+						RawByte: []byte{0x32},
+						Value:   "Exit",
 					},
 				},
 			},
@@ -210,7 +210,7 @@ func TestCompileProgramEndPoint(t *testing.T) {
 	}
 }
 
-func TestCompileRevert(t *testing.T) {
+func TestCompileExit(t *testing.T) {
 	tests := []struct {
 		expect Asm
 	}{
@@ -218,8 +218,8 @@ func TestCompileRevert(t *testing.T) {
 			expect: Asm{
 				AsmCodes: []AsmCode{
 					{
-						RawByte: []byte{0x26},
-						Value:   "Returning",
+						RawByte: []byte{0x32},
+						Value:   "Exit",
 					},
 				},
 			},
@@ -231,10 +231,10 @@ func TestCompileRevert(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		compileRevert(asm)
+		compileExit(asm)
 
 		if !asm.Equal(test.expect) {
-			t.Fatalf("test[%d] - compileRevert() result wrong. expected=%v, got=%v", i, test.expect, asm)
+			t.Fatalf("test[%d] - compileExit() result wrong. expected=%v, got=%v", i, test.expect, asm)
 		}
 	}
 }
@@ -383,14 +383,14 @@ func TestCompileFuncJmpr(t *testing.T) {
 						RawByte: []byte{0x30},
 						Value:   "DUP",
 					},
-					// Push 1b24aabc00000000
+					// Push 00000000c2985578
 					{
 						RawByte: []byte{0x21},
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0x1b, 0x24, 0xaa, 0xbc, 0x00, 0x00, 0x00, 0x00},
-						Value:   "1b24aabc00000000",
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0xc2, 0x98, 0x55, 0x78},
+						Value:   "00000000c2985578",
 					},
 					// EQ
 					{
@@ -421,14 +421,14 @@ func TestCompileFuncJmpr(t *testing.T) {
 						RawByte: []byte{0x30},
 						Value:   "DUP",
 					},
-					// Push 9f24b46700000000
+					// Push 000000007edba6c8
 					{
 						RawByte: []byte{0x21},
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0x9f, 0x24, 0xb4, 0x67, 0x00, 0x00, 0x00, 0x00},
-						Value:   "9f24b46700000000",
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x7e, 0xdb, 0xa6, 0xc8},
+						Value:   "000000007edba6c8 ",
 					},
 					// EQ
 					{
@@ -454,10 +454,10 @@ func TestCompileFuncJmpr(t *testing.T) {
 						RawByte: []byte{0x29},
 						Value:   "Jumpi",
 					},
-					// Returning
+					// Exit
 					{
-						RawByte: []byte{0x26},
-						Value:   "Returning",
+						RawByte: []byte{0x32},
+						Value:   "Exit",
 					},
 				},
 			},
@@ -730,13 +730,13 @@ func TestFillFuncJmpr(t *testing.T) {
 
 func TestCompileFuncSel(t *testing.T) {
 	tests := []struct {
-		funcSel string
+		funcSel []byte
 		funcDst int
 		expect  *Asm
 		err     error
 	}{
 		{
-			funcSel: string(abi.Selector("func Foo()")),
+			funcSel: abi.Selector("Foo()"),
 			funcDst: 15,
 			expect: &Asm{
 				AsmCodes: []AsmCode{
@@ -751,8 +751,8 @@ func TestCompileFuncSel(t *testing.T) {
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0xe3, 0x17, 0x0d, 0xe1, 0x00, 0x00, 0x00, 0x00},
-						Value:   "e3170de100000000",
+						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0xbf, 0xb4, 0xeb, 0xcf},
+						Value:   "00000000bfb4ebcf",
 					},
 					// EQ
 					{

--- a/translate/compiler_internal_test.go
+++ b/translate/compiler_internal_test.go
@@ -290,8 +290,8 @@ func TestCompileFuncJmpr(t *testing.T) {
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0xc5, 0xd2, 0x46, 0x01, 0x00, 0x00, 0x00, 0x00},
-						Value:   "c5d2460100000000",
+						RawByte: abi.Selector(string([]byte("foo()")[:])),
+						Value:   string(abi.Selector(string([]byte("foo()")[:]))[:]),
 					},
 					// EQ
 					{
@@ -328,8 +328,8 @@ func TestCompileFuncJmpr(t *testing.T) {
 						Value:   "Push",
 					},
 					{
-						RawByte: []byte{0xc5, 0xd2, 0x46, 0x01, 0x00, 0x00, 0x00, 0x00},
-						Value:   "c5d2460100000000",
+						RawByte: abi.Selector(string([]byte("sam()")[:])),
+						Value:   string(abi.Selector(string([]byte("sam()")[:]))[:]),
 					},
 					// EQ
 					{
@@ -428,7 +428,7 @@ func TestCompileFuncJmpr(t *testing.T) {
 					},
 					{
 						RawByte: []byte{0x00, 0x00, 0x00, 0x00, 0x7e, 0xdb, 0xa6, 0xc8},
-						Value:   "000000007edba6c8 ",
+						Value:   "000000007edba6c8",
 					},
 					// EQ
 					{
@@ -462,10 +462,10 @@ func TestCompileFuncJmpr(t *testing.T) {
 				},
 			},
 			funcMap: FuncMap{
-				string(abi.Selector("FuncJmpr")):   3,
-				string(abi.Selector("Revert")):     10,
-				string(abi.Selector("func foo()")): 19,
-				string(abi.Selector("func sam()")): 24,
+				string(abi.Selector("FuncJmpr")): 3,
+				string(abi.Selector("Revert")):   10,
+				string(abi.Selector("foo()")):    19,
+				string(abi.Selector("sam()")):    24,
 			},
 			err: nil,
 		},

--- a/vm/stack.go
+++ b/vm/stack.go
@@ -24,46 +24,46 @@ const (
 
 type item int64
 
-// Stack is an object for basic stack operations. Items popped to the stack are
+// Stack is an object for basic Stack operations. Items popped to the Stack are
 // expected not to be changed and modified.
-type stack struct {
+type Stack struct {
 	items []item
 }
 
-func newStack() *stack {
-	return &stack{items: make([]item, 0, stackMaxSize)}
+func newStack() *Stack {
+	return &Stack{items: make([]item, 0, stackMaxSize)}
 }
 
-func (s *stack) push(d item) {
+func (s *Stack) Push(d item) {
 	s.items = append(s.items, d)
 }
 
-// Push n number of data([]data) to stack
-func (s *stack) pushN(ds ...item) {
+// Push n number of data([]data) to Stack
+func (s *Stack) PushN(ds ...item) {
 	s.items = append(s.items, ds...)
 }
 
-func (s *stack) pop() item {
+func (s *Stack) Pop() item {
 	item := s.items[len(s.items)-1]
 	s.items = s.items[:len(s.items)-1]
 	return item
 }
 
-func (s *stack) len() int {
+func (s *Stack) Len() int {
 	return len(s.items)
 }
 
-func (s *stack) dup() {
-	s.push(s.items[s.len()-1])
+func (s *Stack) Dup() {
+	s.Push(s.items[s.Len()-1])
 }
 
-func (s *stack) swap() {
-	s.items[s.len()-2], s.items[s.len()-1] = s.items[s.len()-1], s.items[s.len()-2]
+func (s *Stack) Swap() {
+	s.items[s.Len()-2], s.items[s.Len()-1] = s.items[s.Len()-1], s.items[s.Len()-2]
 }
 
-// Print dumps the content of the stack
-func (s *stack) print() {
-	fmt.Println("### stack ###")
+// Print dumps the content of the Stack
+func (s *Stack) Print() {
+	fmt.Println("### Stack ###")
 	if len(s.items) > 0 {
 		for i, val := range s.items {
 			fmt.Printf("%-3d  %v\n", i, val)

--- a/vm/stack_internal_test.go
+++ b/vm/stack_internal_test.go
@@ -30,7 +30,7 @@ func TestStack_new(t *testing.T) {
 func TestStack_pushN(t *testing.T) {
 	stack := newStack()
 
-	stack.pushN(item(1), item(2), item(3))
+	stack.PushN(item(1), item(2), item(3))
 
 	if len(stack.items) != 3 {
 		t.Fatalf("PushN did not work properly")
@@ -40,9 +40,9 @@ func TestStack_pushN(t *testing.T) {
 func TestStack_push(t *testing.T) {
 	stack := newStack()
 
-	stack.push(item(1))
-	stack.push(item(2))
-	stack.push(item(3))
+	stack.Push(item(1))
+	stack.Push(item(2))
+	stack.Push(item(3))
 	if len(stack.items) != 3 {
 		t.Fatalf("Push did not work properly")
 	}
@@ -51,12 +51,12 @@ func TestStack_push(t *testing.T) {
 func TestStack_pop(t *testing.T) {
 	stack := newStack()
 
-	stack.push(item(1))
-	stack.push(item(2))
-	stack.push(item(3))
+	stack.Push(item(1))
+	stack.Push(item(2))
+	stack.Push(item(3))
 
 	for i := len(stack.items); i > 0; i-- {
-		if stack.pop() != item(i) {
+		if stack.Pop() != item(i) {
 			t.Fatalf("Pop error at stack point %d", i)
 		}
 	}
@@ -69,11 +69,11 @@ func TestStack_pop(t *testing.T) {
 func TestStack_len(t *testing.T) {
 	stack := newStack()
 
-	stack.push(item(1))
-	stack.push(item(2))
-	stack.push(item(3))
+	stack.Push(item(1))
+	stack.Push(item(2))
+	stack.Push(item(3))
 
-	if len(stack.items) != stack.len() {
+	if len(stack.items) != stack.Len() {
 		t.Fatal("function len is invalid")
 	}
 }
@@ -81,9 +81,9 @@ func TestStack_len(t *testing.T) {
 func TestStack_print(t *testing.T) {
 	stack := newStack()
 
-	stack.push(item(1))
-	stack.push(item(2))
-	stack.push(item(3))
+	stack.Push(item(1))
+	stack.Push(item(2))
+	stack.Push(item(3))
 
 	//	### stack ###
 	//	0    1
@@ -91,5 +91,5 @@ func TestStack_print(t *testing.T) {
 	//	2    3
 	//	#############
 
-	stack.print()
+	stack.Print()
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -37,18 +37,18 @@ var ErrInvalidOpcode = errors.New("invalid opcode")
 
 // The Execute function assemble the rawByteCode into an assembly code,
 // which in turn executes the assembly logic.
-func Execute(rawByteCode []byte, memory *Memory, callFunc *CallFunc) (*stack, error) {
+func Execute(rawByteCode []byte, memory *Memory, callFunc *CallFunc) (*Stack, error) {
 
 	s := newStack()
 	asm, err := disassemble(rawByteCode)
 	if err != nil {
-		return &stack{}, err
+		return &Stack{}, err
 	}
 
 	for h := asm.code[0]; h != nil; h = asm.next() {
 		op, ok := h.(opCode)
 		if !ok {
-			return &stack{}, ErrInvalidOpcode
+			return &Stack{}, ErrInvalidOpcode
 		}
 
 		err := op.Do(s, asm, memory, callFunc)
@@ -99,7 +99,7 @@ func (cf CallFunc) arguments(n int) []byte {
 }
 
 type opCode interface {
-	Do(*stack, asmReader, *Memory, *CallFunc) error
+	Do(*Stack, asmReader, *Memory, *CallFunc) error
 	hexer
 }
 
@@ -138,11 +138,11 @@ type dup struct{}
 type swap struct{}
 type exit struct{}
 
-func (add) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (add) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
-	stack.push(x + y)
+	stack.Push(x + y)
 
 	return nil
 }
@@ -151,11 +151,11 @@ func (add) hex() []uint8 {
 	return []uint8{uint8(opcode.Add)}
 }
 
-func (mul) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (mul) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
-	stack.push(x * y)
+	stack.Push(x * y)
 
 	return nil
 }
@@ -164,11 +164,11 @@ func (mul) hex() []uint8 {
 	return []uint8{uint8(opcode.Mul)}
 }
 
-func (sub) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (sub) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
-	stack.push(x - y)
+	stack.Push(x - y)
 
 	return nil
 }
@@ -178,13 +178,13 @@ func (sub) hex() []uint8 {
 }
 
 // Be careful! int.Div and int.Quo is different
-func (div) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (div) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
 	item, _ := euclidean_div(x, y)
 
-	stack.push(item)
+	stack.Push(item)
 
 	return nil
 }
@@ -193,13 +193,13 @@ func (div) hex() []uint8 {
 	return []uint8{uint8(opcode.Div)}
 }
 
-func (mod) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (mod) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
 	_, item := euclidean_div(x, y)
 
-	stack.push(item)
+	stack.Push(item)
 
 	return nil
 }
@@ -208,13 +208,13 @@ func (mod) hex() []uint8 {
 	return []uint8{uint8(opcode.Mod)}
 }
 
-func (and) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (and) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
 	ret := x & y
 
-	stack.push(ret)
+	stack.Push(ret)
 
 	return nil
 }
@@ -223,13 +223,13 @@ func (and) hex() []uint8 {
 	return []uint8{uint8(opcode.And)}
 }
 
-func (or) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y := stack.pop()
-	x := stack.pop()
+func (or) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y := stack.Pop()
+	x := stack.Pop()
 
 	ret := x | y
 
-	stack.push(ret)
+	stack.Push(ret)
 
 	return nil
 }
@@ -238,13 +238,13 @@ func (or) hex() []uint8 {
 	return []uint8{uint8(opcode.Or)}
 }
 
-func (lt) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y, x := stack.pop(), stack.pop()
+func (lt) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y, x := stack.Pop(), stack.Pop()
 
 	if x < y { // x < y
-		stack.push(item(1))
+		stack.Push(item(1))
 	} else {
-		stack.push(item(0))
+		stack.Push(item(0))
 	}
 
 	return nil
@@ -254,13 +254,13 @@ func (lt) hex() []uint8 {
 	return []uint8{uint8(opcode.LT)}
 }
 
-func (lte) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y, x := stack.pop(), stack.pop()
+func (lte) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y, x := stack.Pop(), stack.Pop()
 
 	if x <= y { // x <= y
-		stack.push(item(1))
+		stack.Push(item(1))
 	} else {
-		stack.push(item(0))
+		stack.Push(item(0))
 	}
 
 	return nil
@@ -270,13 +270,13 @@ func (lte) hex() []uint8 {
 	return []uint8{uint8(opcode.LTE)}
 }
 
-func (gt) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y, x := stack.pop(), stack.pop()
+func (gt) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y, x := stack.Pop(), stack.Pop()
 
 	if x > y { // x > y
-		stack.push(item(1))
+		stack.Push(item(1))
 	} else {
-		stack.push(item(0))
+		stack.Push(item(0))
 	}
 
 	return nil
@@ -286,13 +286,13 @@ func (gt) hex() []uint8 {
 	return []uint8{uint8(opcode.GT)}
 }
 
-func (gte) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y, x := stack.pop(), stack.pop()
+func (gte) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y, x := stack.Pop(), stack.Pop()
 
 	if x >= y { // x >= y
-		stack.push(item(1))
+		stack.Push(item(1))
 	} else {
-		stack.push(item(0))
+		stack.Push(item(0))
 	}
 
 	return nil
@@ -302,13 +302,13 @@ func (gte) hex() []uint8 {
 	return []uint8{uint8(opcode.GTE)}
 }
 
-func (eq) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	y, x := stack.pop(), stack.pop()
+func (eq) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	y, x := stack.Pop(), stack.Pop()
 
 	if x == y { // x == y
-		stack.push(item(1))
+		stack.Push(item(1))
 	} else {
-		stack.push(item(0))
+		stack.Push(item(0))
 	}
 
 	return nil
@@ -318,8 +318,8 @@ func (eq) hex() []uint8 {
 	return []uint8{uint8(opcode.EQ)}
 }
 
-func (not) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	x := stack.pop()
+func (not) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	x := stack.Pop()
 
 	if x == 1 {
 		x = 0
@@ -327,7 +327,7 @@ func (not) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
 		x = 1
 	}
 
-	stack.push(x)
+	stack.Push(x)
 	return nil
 }
 
@@ -335,8 +335,8 @@ func (not) hex() []uint8 {
 	return []uint8{uint8(opcode.NOT)}
 }
 
-func (pop) Do(stack *stack, _ asmReader, _ *Memory, _ *CallFunc) error {
-	_ = stack.pop()
+func (pop) Do(stack *Stack, _ asmReader, _ *Memory, _ *CallFunc) error {
+	_ = stack.Pop()
 	return nil
 }
 
@@ -344,14 +344,14 @@ func (pop) hex() []uint8 {
 	return []uint8{uint8(opcode.Pop)}
 }
 
-func (push) Do(stack *stack, asm asmReader, _ *Memory, contract *CallFunc) error {
+func (push) Do(stack *Stack, asm asmReader, _ *Memory, contract *CallFunc) error {
 	code := asm.next()
 	data, ok := code.(Data)
 	if !ok {
 		return ErrInvalidData
 	}
 	item := bytesToItem(data.hex())
-	stack.push(item)
+	stack.Push(item)
 
 	return nil
 }
@@ -360,11 +360,11 @@ func (push) hex() []uint8 {
 	return []uint8{uint8(opcode.Push)}
 }
 
-func (mload) Do(stack *stack, _ asmReader, memory *Memory, _ *CallFunc) error {
-	offset, size := stack.pop(), stack.pop()
+func (mload) Do(stack *Stack, _ asmReader, memory *Memory, _ *CallFunc) error {
+	offset, size := stack.Pop(), stack.Pop()
 	value := memory.GetVal(uint64(offset), uint64(size))
 
-	stack.push(bytesToItem(value))
+	stack.Push(bytesToItem(value))
 	return nil
 }
 
@@ -372,8 +372,8 @@ func (mload) hex() []uint8 {
 	return []uint8{uint8(opcode.Mload)}
 }
 
-func (mstore) Do(stack *stack, _ asmReader, memory *Memory, _ *CallFunc) error {
-	offset, size, value := stack.pop(), stack.pop(), stack.pop()
+func (mstore) Do(stack *Stack, _ asmReader, memory *Memory, _ *CallFunc) error {
+	offset, size, value := stack.Pop(), stack.Pop(), stack.Pop()
 
 	memSize := uint64(memory.Len()) + uint64(size)
 	memory.Resize(memSize)
@@ -387,7 +387,7 @@ func (mstore) hex() []uint8 {
 	return []uint8{uint8(opcode.Mstore)}
 }
 
-func (loadfunc) Do(stack *stack, _ asmReader, _ *Memory, callfunc *CallFunc) error {
+func (loadfunc) Do(stack *Stack, _ asmReader, _ *Memory, callfunc *CallFunc) error {
 	function := callfunc.function()
 
 	convertedFunc, err := encoding.EncodeOperand(function)
@@ -395,7 +395,7 @@ func (loadfunc) Do(stack *stack, _ asmReader, _ *Memory, callfunc *CallFunc) err
 		return err
 	}
 
-	stack.push(bytesToItem(convertedFunc))
+	stack.Push(bytesToItem(convertedFunc))
 	return nil
 }
 
@@ -403,11 +403,11 @@ func (loadfunc) hex() []uint8 {
 	return []uint8{uint8(opcode.LoadFunc)}
 }
 
-func (loadargs) Do(stack *stack, _ asmReader, _ *Memory, callfunc *CallFunc) error {
-	index := stack.pop()
+func (loadargs) Do(stack *Stack, _ asmReader, _ *Memory, callfunc *CallFunc) error {
+	index := stack.Pop()
 	argument := callfunc.arguments(int(index))
 
-	stack.push(bytesToItem(argument))
+	stack.Push(bytesToItem(argument))
 
 	return nil
 }
@@ -416,12 +416,12 @@ func (loadargs) hex() []uint8 {
 	return []uint8{uint8(opcode.LoadArgs)}
 }
 
-func (returning) Do(stack *stack, asm asmReader, memory *Memory, _ *CallFunc) error {
-	value, _, pos := stack.pop(), stack.pop(), stack.pop()
+func (returning) Do(stack *Stack, asm asmReader, memory *Memory, _ *CallFunc) error {
+	value, _, pos := stack.Pop(), stack.Pop(), stack.Pop()
 
 	asm.jump(uint64(pos - 1))
 
-	stack.push(value)
+	stack.Push(value)
 	return nil
 }
 
@@ -429,8 +429,8 @@ func (returning) hex() []uint8 {
 	return []uint8{uint8(opcode.Returning)}
 }
 
-func (jump) Do(stack *stack, asm asmReader, memory *Memory, _ *CallFunc) error {
-	pos := stack.pop()
+func (jump) Do(stack *Stack, asm asmReader, memory *Memory, _ *CallFunc) error {
+	pos := stack.Pop()
 	asm.jump(uint64(pos - 1))
 	return nil
 }
@@ -439,7 +439,7 @@ func (jump) hex() []uint8 {
 	return []uint8{uint8(opcode.Jump)}
 }
 
-func (jumpDst) Do(stack *stack, asm asmReader, memory *Memory, _ *CallFunc) error {
+func (jumpDst) Do(stack *Stack, asm asmReader, memory *Memory, _ *CallFunc) error {
 	return nil
 }
 
@@ -447,8 +447,8 @@ func (jumpDst) hex() []uint8 {
 	return []uint8{uint8(opcode.JumpDst)}
 }
 
-func (jumpi) Do(stack *stack, asm asmReader, memory *Memory, _ *CallFunc) error {
-	pos, cond := stack.pop(), stack.pop()
+func (jumpi) Do(stack *Stack, asm asmReader, memory *Memory, _ *CallFunc) error {
+	pos, cond := stack.Pop(), stack.Pop()
 	if cond == item(0) { // cond == false
 		asm.jump(uint64(pos - 1))
 	}
@@ -459,8 +459,8 @@ func (jumpi) hex() []uint8 {
 	return []uint8{uint8(opcode.Jumpi)}
 }
 
-func (dup) Do(stack *stack, _ asmReader, memory *Memory, _ *CallFunc) error {
-	stack.dup()
+func (dup) Do(stack *Stack, _ asmReader, memory *Memory, _ *CallFunc) error {
+	stack.Dup()
 	return nil
 }
 
@@ -468,8 +468,8 @@ func (dup) hex() []uint8 {
 	return []uint8{uint8(opcode.DUP)}
 }
 
-func (swap) Do(stack *stack, _ asmReader, memory *Memory, _ *CallFunc) error {
-	stack.swap()
+func (swap) Do(stack *Stack, _ asmReader, memory *Memory, _ *CallFunc) error {
+	stack.Swap()
 	return nil
 }
 
@@ -477,7 +477,7 @@ func (swap) hex() []uint8 {
 	return []uint8{uint8(opcode.SWAP)}
 }
 
-func (exit) Do(stack *stack, asm asmReader, memory *Memory, _ *CallFunc) error {
+func (exit) Do(stack *Stack, asm asmReader, memory *Memory, _ *CallFunc) error {
 	for asm.next() != nil {
 	}
 	return nil

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -209,7 +209,7 @@ func TestExecute(t *testing.T) {
 			t.Error(err)
 		}
 
-		result := stack.pop()
+		result := stack.Pop()
 		if result != test.result {
 			t.Errorf("Invalid result - expected = %d, got = %d", test.result, result)
 		}
@@ -228,9 +228,9 @@ func TestAdd(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -246,9 +246,9 @@ func TestAdd_negative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -264,9 +264,9 @@ func TestMul(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -282,9 +282,9 @@ func TestMul_negative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -300,9 +300,9 @@ func TestSub(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -318,9 +318,9 @@ func TestSub_negative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -337,9 +337,9 @@ func TestDiv(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -356,9 +356,9 @@ func TestDiv_negative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -374,9 +374,9 @@ func TestMod(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -392,9 +392,9 @@ func TestMod_negative(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -410,9 +410,9 @@ func TestAnd(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -428,9 +428,9 @@ func TestOr(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	result := stack.pop()
+	result := stack.Pop()
 	if testExpected != result {
-		t.Errorf("stack.pop() result wrong - expected=%d, got=%d", testExpected, result)
+		t.Errorf("stack.Pop() result wrong - expected=%d, got=%d", testExpected, result)
 	}
 }
 
@@ -458,9 +458,9 @@ func TestLT(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -491,9 +491,9 @@ func TestLTE(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -522,9 +522,9 @@ func TestGT(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -555,9 +555,9 @@ func TestGTE(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -586,9 +586,9 @@ func TestEQ(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -613,9 +613,9 @@ func TestNOT(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-		result := stack.pop()
+		result := stack.Pop()
 		if testExpected != result {
-			t.Errorf("test[%d]:stack.pop() result wrong - expected=%d, got=%d", i, testExpected, result)
+			t.Errorf("test[%d]:stack.Pop() result wrong - expected=%d, got=%d", i, testExpected, result)
 		}
 	}
 }
@@ -634,7 +634,7 @@ func TestPop(t *testing.T) {
 	}
 
 	if len(stack.items) != 1 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -658,7 +658,7 @@ func TestPush(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -718,12 +718,12 @@ func TestMload(t *testing.T) {
 		t.Error(err)
 	}
 
-	if stack.len() != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.len())
+	if stack.Len() != 2 {
+		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.Len())
 	}
 
 	for _, test := range testExpected {
-		value := stack.pop()
+		value := stack.Pop()
 		if !bytes.Equal(int64ToBytes(int64(value)), test.value) {
 			t.Errorf("Invalid memory value - expected=%x, got=%x", test.value, value)
 		}
@@ -766,8 +766,8 @@ func TestMstore(t *testing.T) {
 		t.Error(err)
 	}
 
-	if stack.len() != 0 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.len())
+	if stack.Len() != 0 {
+		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.Len())
 	}
 
 	for _, test := range testExpected {
@@ -794,11 +794,11 @@ func TestLoadFunc(t *testing.T) {
 		t.Error(err)
 	}
 
-	if stack.len() != 1 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.len())
+	if stack.Len() != 1 {
+		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.Len())
 	}
 
-	if !bytes.Equal(int64ToBytes(int64(stack.pop())), testExpected) {
+	if !bytes.Equal(int64ToBytes(int64(stack.Pop())), testExpected) {
 		t.Error("Invalid")
 	}
 }
@@ -840,12 +840,12 @@ func TestLoadArgs(t *testing.T) {
 		t.Error(err)
 	}
 
-	if stack.len() != 3 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.len())
+	if stack.Len() != 3 {
+		t.Errorf("Invalid stack size - expected=%d, got =%d", 0, stack.Len())
 	}
 
 	for _, expected := range testExpected {
-		value := stack.pop()
+		value := stack.Pop()
 		if !bytes.Equal(int64ToBytes(int64(value)), expected.value) {
 			t.Errorf("Invalid bytes - expected = %x, got = %x", expected.value, value)
 		}
@@ -872,7 +872,7 @@ func TestReturning(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -900,7 +900,7 @@ func TestExit(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -937,7 +937,7 @@ func TestJumpOp(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -965,7 +965,7 @@ func TestJumpiJump(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -994,7 +994,7 @@ func TestJumpiNotJump(t *testing.T) {
 	}
 
 	if len(stack.items) != 1 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -1018,7 +1018,7 @@ func TestDUP(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {
@@ -1043,7 +1043,7 @@ func TestSWAP(t *testing.T) {
 	}
 
 	if len(stack.items) != 2 {
-		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.len())
+		t.Errorf("Invalid stack size - expected=%d, got =%d", len(testExpected), stack.Len())
 	}
 
 	for i, item := range stack.items {


### PR DESCRIPTION
details:

@zeroFruit 

If we have this function,
```go
func A(a int, b int){
}
```
we can get function selector by `A(int,int)` 

but this method make as A(parameter : identifier : ....  maybe?

I think below method has matter so  plz modify!

```go
func (p *ParameterLiteral) String() string {
	return fmt.Sprintf("Parameter : (Identifier: %s, Type: %s)", p.Identifier.String(), p.Type.String())
}
```
- [x] Test case